### PR TITLE
Add option for counter selector

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -43,12 +43,9 @@
 	})();
 
 	window.gitHubNotifCount = function (callback) {
-		var NOTIFICATIONS_URL = GitHubNotify.settings.get('notificationUrl');
-		var USE_PARTICIPATING = GitHubNotify.settings.get('useParticipatingCount');
-
 		var tmp = document.createElement('div');
 
-		xhr('GET', NOTIFICATIONS_URL, function (data, status) {
+		xhr('GET', GitHubNotify.settings.get('notificationUrl'), function (data, status) {
 			if (status >= 400) {
 				callback(-1);
 				return;
@@ -56,7 +53,9 @@
 
 			tmp.innerHTML = data;
 
-			var participating = (USE_PARTICIPATING) ? '/participating' : '';
+			var participating = (GitHubNotify.settings.get('useParticipatingCount'))
+				? '/participating'
+				: '';
 			var countElem = tmp.querySelector('a[href="/notifications' + participating + '"] .count');
 			if (countElem) {
 				callback(countElem.textContent !== '0' ? countElem.textContent : '');

--- a/extension/main.js
+++ b/extension/main.js
@@ -36,6 +36,7 @@
 
 	chrome.alarms.create({periodInMinutes: 1});
 	chrome.alarms.onAlarm.addListener(update);
+	chrome.runtime.onMessage.addListener(update);
 
 	chrome.browserAction.onClicked.addListener(function () {
 		chrome.tabs.create({

--- a/extension/options.html
+++ b/extension/options.html
@@ -53,10 +53,9 @@
 							<input type="text" id="notification_url" autofocus>
 						</section>
 						<section>
-							<h3>Use Participating Count</h3>
-							<p>Check this if you only want updates for issues you're participating in</p>
+							<h3>Participating Count</h3>
 							<input type="checkbox" id="use_participating">
-							<label for="use_participating">Use participating count</label>
+							<label for="use_participating">Only show unread count for issues I'm participating in</label>
 						</section>
 						<div class="controls">
 							<button id="save">Save</button>

--- a/extension/options.js
+++ b/extension/options.js
@@ -14,6 +14,15 @@
 
 		loadSettings();
 
+		function updateBadge() {
+			chrome.runtime.sendMessage('update');
+		}
+
+		formUseParticipating.addEventListener('change', function() {
+			GitHubNotify.settings.set('useParticipatingCount', formUseParticipating.checked);
+			updateBadge();
+		});
+
 		document.getElementById('save').addEventListener('click', function () {
 			chrome.permissions.request({
 				origins: [formNotificationUrl.value]
@@ -28,7 +37,7 @@
 				}
 			});
 
-			GitHubNotify.settings.set('useParticipatingCount', formUseParticipating.checked);
+			updateBadge();
 
 			clearTimeout(successTimeout);
 


### PR DESCRIPTION
Been using this extension for a long time and had a minor custom modification that disappeared during the latest update, so figured I'd flesh it out a little and make it permanent.

My team updates a ton of crap every day and I prefer to get alerted just for things I'm participating in, so this  PR will let you specify the selector used to get the count on the notifications page. In my case, I just modify it to use `a[href="/notifications/participating"] .count`, but you could also in theory change it to be any other project-specific selector, too. It gets a little more nebulous at that point, since those are only visible if there _are_ updates, so I've just erred on the side of "the user knows what they're doing".

I also added a test button on the options page so you can make sure the selector and custom URL are working and a success message once you hit save.
