### PR TITLE
Focus on existing tab instead of creating

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -38,16 +38,28 @@
 	chrome.alarms.onAlarm.addListener(update);
 	chrome.runtime.onMessage.addListener(update);
 
-	chrome.browserAction.onClicked.addListener(function (tab) {
-		var notifTab = {
-			url: GitHubNotify.settings.get('notificationUrl') 
-		};
-		if (tab.url === '' || tab.url === 'chrome://newtab/' || tab.url === notifTab.url) {
-			chrome.tabs.update(null, notifTab);
-		} else {
-			chrome.tabs.create(notifTab);
-		}
-	});
+	function getGitUrl() {
+		return GitHubNotify.settings.get('notificationUrl');
+	}
+
+	function goToNotification() {
+		chrome.tabs.query({currentWindow: true}, function(tabs) {
+			for (var i = 0, tab; tab = tabs[i]; i++) {
+				if (tab.url === getGitUrl()) {
+					chrome.tabs.update(tab.id, {selected: true, url: getGitUrl()});
+					return;
+				}
+			}
+			chrome.tabs.query({active: true}, function(tabs){
+				if (tabs[0].url === 'chrome://newtab/') {
+					chrome.tabs.update(tabs[0].id, {url: getGitUrl()})
+				} else {
+					chrome.tabs.create({url: getGitUrl()});
+				}
+			});
+		});
+	}
+	chrome.browserAction.onClicked.addListener(goToNotification);
 
 	update();
 })();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,7 +12,7 @@
 	},
 	"permissions": [
 		"alarms",
-		"activeTab",
+		"tabs",
 		"https://github.com/"
 	],
 	"optional_permissions": [


### PR DESCRIPTION
Minor addition for ease of use.

If a notification tab is already active, we now focus on that tab and refresh it.
If not, we maintain the previous logic.
This requires an upgrade in permissions in order to check all the tabs' url.
