### PR TITLE
grant XHR to any URL for GitHub Enterprise

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,7 +13,7 @@
 	"permissions": [
 		"alarms",
 		"activeTab",
-		"https://github.com/"
+		"*://*/"
 	],
 	"optional_permissions": [
 		"*://*/"


### PR DESCRIPTION
hello!

I encounterd almost same problem #5 while Im using private ghe.
Of cource, I set correct notification URL.

I took a look a bug and found chrome caused an error about 'Allow-Control-Allow-Origin'.
I thought need more permission for ghe URL.
https://github.com/sindresorhus/github-notifier-chrome/blob/master/extension/manifest.json#L16

I clone this extension and rewrite "https://github.com/" to "_://_/".
Now works right now.
