### PR TITLE
Simplify GitHubNotify.settings

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -32,10 +32,7 @@
 					return item;
 				},
 				set: localStorage.setItem.bind(localStorage),
-				reset: function () {
-					Object.keys(localStorage).forEach(api.settings.revert);
-				},
-				revert: localStorage.removeItem.bind(localStorage)
+				reset: localStorage.clear.bind(localStorage)
 			}
 		};
 


### PR DESCRIPTION
Simplify `GitHubmNotify.settings`. I don't see why we couldn't use `localStorage.clear` here.
