### PR TITLE
WIP. Use storage.sync

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -67,7 +67,7 @@ function handleOfflineStatus() {
 async function handleBrowserActionClick(tab) {
 	const tabUrl = await API.getTabUrl();
 
-	// request optional permissions the 1rst time
+	// Request optional permissions the 1rst time
 	const tabsAlreadyGranted = await PersistenceService.get('tabs_permission');
 	if (tabsAlreadyGranted === undefined) {
 		const granted = await PermissionsService.requestPermission('tabs');
@@ -87,6 +87,20 @@ function handleConnectionStatus(event) {
 		scheduleAlaram();
 	} else if (event.type === 'offline') {
 		handleOfflineStatus();
+	}
+}
+
+async function checkDesktopNotificationsPermission() {
+	const granted = await PermissionsService.queryPermission('notifications');
+
+	if (granted) {
+		window.chrome.notifications.onClicked.addListener(id => {
+			NotificationsService.openNotification(id);
+		});
+
+		window.chrome.notifications.onClosed.addListener(id => {
+			NotificationsService.removeNotification(id);
+		});
 	}
 }
 

--- a/extension/main.js
+++ b/extension/main.js
@@ -109,11 +109,9 @@ window.addEventListener('offline', handleConnectionStatus);
 
 window.chrome.alarms.create({when: Date.now() + 2000});
 window.chrome.alarms.onAlarm.addListener(update);
+window.chrome.browserAction.onClicked.addListener(handleBrowserActionClick);
 window.chrome.runtime.onMessage.addListener(update);
+window.chrome.runtime.onInstalled.addListener(handleInstalled);
 
 checkDesktopNotificationsPermission();
-
-window.chrome.runtime.onInstalled.addListener(handleInstalled);
-window.chrome.browserAction.onClicked.addListener(handleBrowserActionClick);
-
 update();

--- a/extension/main.js
+++ b/extension/main.js
@@ -5,7 +5,7 @@ const PermissionsService = require('./src/permissions-service');
 const PersistenceService = require('./src/persistence-service');
 const TabsService = require('./src/tabs-service');
 
-const handleInterval = async interval => {
+async function handleInterval(interval) {
 	const intervalSetting = await PersistenceService.get('interval');
 	const intervalValue = interval || 60;
 
@@ -19,7 +19,7 @@ const handleInterval = async interval => {
 	window.chrome.alarms.create({delayInMinutes});
 }
 
-const handleLastModified = async date => {
+async function handleLastModified(date) {
 	let lastModified = await PersistenceService.get('lastModified');
 	const emptyLastModified = String(lastModified) === 'null' || String(lastModified) === 'undefined';
 	lastModified = emptyLastModified ? new Date(0) : lastModified;
@@ -33,7 +33,7 @@ const handleLastModified = async date => {
 	}
 }
 
-const handleNotificationsResponse = async response => {
+async function handleNotificationsResponse(response) {
 	const {count, interval, lastModified} = response;
 
 	await handleInterval(interval);
@@ -42,12 +42,12 @@ const handleNotificationsResponse = async response => {
 	BadgeService.renderCount(count);
 }
 
-const update = async () => {
+async function update() {
 	try {
 		const response = await API.getNotifications();
 		handleNotificationsResponse(response);
-	} catch (e) {
-		handleError(e);
+	} catch (err) {
+		handleError(err);
 	}
 }
 
@@ -55,7 +55,7 @@ function handleError(error) {
 	BadgeService.renderError(error);
 }
 
-const handleBrowserActionClick = async tab => {
+async function handleBrowserActionClick(tab) {
 	const tabUrl = await API.getTabUrl();
 
 	// request optional permissions the 1rst time
@@ -65,7 +65,7 @@ const handleBrowserActionClick = async tab => {
 		await PersistenceService.set('tabs_permission', granted);
 	}
 	await TabsService.openTab(tabUrl, tab);
-};
+}
 
 function handleInstalled(details) {
 	if (details.reason === 'install') {
@@ -73,7 +73,7 @@ function handleInstalled(details) {
 	}
 }
 
-const checkDesktopNotificationsPermission = async () => {
+async function checkDesktopNotificationsPermission() {
 	const granted = await PermissionsService.queryPermission('notifications');
 	if (granted) {
 		window.chrome.notifications.onClicked.addListener(id => {
@@ -84,7 +84,7 @@ const checkDesktopNotificationsPermission = async () => {
 			NotificationsService.removeNotification(id);
 		});
 	}
-};
+}
 
 window.chrome.alarms.create({when: Date.now() + 2000});
 window.chrome.alarms.onAlarm.addListener(update);

--- a/extension/main.js
+++ b/extension/main.js
@@ -5,12 +5,12 @@ const PermissionsService = require('./src/permissions-service');
 const PersistenceService = require('./src/persistence-service');
 const TabsService = require('./src/tabs-service');
 
-function handleInterval(interval) {
-	const intervalSetting = parseInt(PersistenceService.get('interval'), 10) || 60;
+const handleInterval = async interval => {
+	const intervalSetting = await PersistenceService.get('interval');
 	const intervalValue = interval || 60;
 
 	if (intervalSetting !== intervalValue) {
-		PersistenceService.set('interval', intervalValue);
+		await PersistenceService.set('interval', intervalValue);
 	}
 
 	// delay less than 1 minute will cause a warning
@@ -19,49 +19,53 @@ function handleInterval(interval) {
 	window.chrome.alarms.create({delayInMinutes});
 }
 
-function handleLastModified(date) {
-	let lastModified = PersistenceService.get('lastModified');
+const handleLastModified = async date => {
+	let lastModified = await PersistenceService.get('lastModified');
 	const emptyLastModified = String(lastModified) === 'null' || String(lastModified) === 'undefined';
 	lastModified = emptyLastModified ? new Date(0) : lastModified;
 
 	if (date !== lastModified) {
-		PersistenceService.set('lastModified', date);
-		if (PersistenceService.get('showDesktopNotif') === true) {
+		await PersistenceService.set('lastModified', date);
+		const showDesktopNotif = await PersistenceService.get('showDesktopNotif');
+		if (showDesktopNotif) {
 			NotificationsService.checkNotifications(lastModified);
 		}
 	}
 }
 
-function handleNotificationsResponse(response) {
+const handleNotificationsResponse = async response => {
 	const {count, interval, lastModified} = response;
 
-	handleInterval(interval);
-	handleLastModified(lastModified);
+	await handleInterval(interval);
+	await handleLastModified(lastModified);
 
 	BadgeService.renderCount(count);
 }
 
-function update() {
-	API.getNotifications().then(handleNotificationsResponse).catch(handleError);
+const update = async () => {
+	try {
+		const response = await API.getNotifications();
+		handleNotificationsResponse(response);
+	} catch (e) {
+		handleError(e);
+	}
 }
 
 function handleError(error) {
 	BadgeService.renderError(error);
 }
 
-function handleBrowserActionClick(tab) {
-	const tabUrl = API.getTabUrl();
+const handleBrowserActionClick = async tab => {
+	const tabUrl = await API.getTabUrl();
 
 	// request optional permissions the 1rst time
-	if (PersistenceService.get('tabs_permission') === undefined) {
-		PermissionsService.requestPermission('tabs').then(granted => {
-			PersistenceService.set('tabs_permission', granted);
-			TabsService.openTab(tabUrl, tab);
-		});
-	} else {
-		TabsService.openTab(tabUrl, tab);
+	const tabsAlreadyGranted = await PersistenceService.get('tabs_permission');
+	if (tabsAlreadyGranted === undefined) {
+		const granted = await PermissionsService.requestPermission('tabs');
+		await PersistenceService.set('tabs_permission', granted);
 	}
-}
+	await TabsService.openTab(tabUrl, tab);
+};
 
 function handleInstalled(details) {
 	if (details.reason === 'install') {
@@ -69,11 +73,8 @@ function handleInstalled(details) {
 	}
 }
 
-window.chrome.alarms.create({when: Date.now() + 2000});
-window.chrome.alarms.onAlarm.addListener(update);
-window.chrome.runtime.onMessage.addListener(update);
-
-PermissionsService.queryPermission('notifications').then(granted => {
+const checkDesktopNotificationsPermission = async () => {
+	const granted = await PermissionsService.queryPermission('notifications');
 	if (granted) {
 		window.chrome.notifications.onClicked.addListener(id => {
 			NotificationsService.openNotification(id);
@@ -83,7 +84,13 @@ PermissionsService.queryPermission('notifications').then(granted => {
 			NotificationsService.removeNotification(id);
 		});
 	}
-});
+};
+
+window.chrome.alarms.create({when: Date.now() + 2000});
+window.chrome.alarms.onAlarm.addListener(update);
+window.chrome.runtime.onMessage.addListener(update);
+
+checkDesktopNotificationsPermission();
 
 window.chrome.runtime.onInstalled.addListener(handleInstalled);
 window.chrome.browserAction.onClicked.addListener(handleBrowserActionClick);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Notifier for GitHub",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Displays your GitHub notifications unread count",
 	"homepage_url": "https://github.com/sindresorhus/notifier-for-github-chrome",
 	"manifest_version": 2,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,12 +4,13 @@
 	"description": "Displays your GitHub notifications unread count",
 	"homepage_url": "https://github.com/sindresorhus/notifier-for-github-chrome",
 	"manifest_version": 2,
-	"minimum_chrome_version": "52",
+	"minimum_chrome_version": "55",
 	"icons": {
 		"128": "icon-128.png"
 	},
 	"permissions": [
-		"alarms"
+		"alarms",
+		"storage"
 	],
 	"optional_permissions": [
 		"tabs",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Notifier for GitHub",
-	"version": "3.0.2",
+	"version": "3.0.1",
 	"description": "Displays your GitHub notifications unread count",
 	"homepage_url": "https://github.com/sindresorhus/notifier-for-github-chrome",
 	"manifest_version": 2,

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,4 +1,5 @@
 const Option = require('./src/option');
+const Defaults = require('./src/defaults');
 const PermissionsService = require('./src/permissions-service');
 const PersistenceService = require('./src/persistence-service');
 
@@ -10,21 +11,21 @@ document.addEventListener('DOMContentLoaded', () => {
 		id: 'root_url',
 		storageKey: 'rootUrl',
 		valueType: 'value',
-		onChange: option => {
+		async onChange(option) {
 			let url = normalizeRoot(option.element.value);
 
 			const urlSettings = `${normalizeRoot(option.element.value)}settings/tokens/new?scopes=notifications`;
 
 			// case of url is empty: set to default
 			if (url === normalizeRoot('')) {
-				PersistenceService.remove('rootUrl');
-				url = PersistenceService.get('rootUrl');
+				await PersistenceService.remove('rootUrl');
+				url = Defaults.get('rootUrl');
 			}
 
-			option.writeValue(url);
+			await option.writeValue(url);
 			ghSettingsUrl.href = urlSettings;
 			updateBadge();
-			reloadSettings();
+			await reloadSettings();
 		}
 	});
 
@@ -32,8 +33,8 @@ document.addEventListener('DOMContentLoaded', () => {
 		id: 'oauth_token',
 		storageKey: 'oauthToken',
 		valueType: 'value',
-		onChange(option) {
-			option.writeValue();
+		async onChange(option) {
+			await option.writeValue();
 			updateBadge();
 		}
 	});
@@ -42,8 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
 		id: 'use_participating',
 		storageKey: 'useParticipatingCount',
 		valueType: 'checked',
-		onChange(option) {
-			option.writeValue();
+		async onChange(option) {
+			await option.writeValue();
 			updateBadge();
 		}
 	});
@@ -52,15 +53,13 @@ document.addEventListener('DOMContentLoaded', () => {
 		id: 'show_desktop_notif',
 		storageKey: 'showDesktopNotif',
 		valueType: 'checked',
-		onChange(option) {
+		async onChange(option) {
 			if (showDesktopNotif.checked) {
-				PermissionsService.requestPermission('notifications').then(granted => {
-					if (granted) {
-						updateBadge();
-					}
-
-					option.writeValue(granted);
-				});
+				const granted = PermissionsService.requestPermission('notifications');
+				if (granted) {
+					updateBadge();
+				}
+				await option.writeValue(granted);
 			} else {
 				option.writeValue();
 			}
@@ -85,9 +84,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	function reloadSettings() {
-		RootUrlOption.readValue();
-		OauthTokenOption.readValue();
-		UseParticipatingCountOption.readValue();
-		ShowDesktopNotificationsOption.readValue();
+		return Promise.all([
+			RootUrlOption.readValue(),
+			OauthTokenOption.readValue(),
+			UseParticipatingCountOption.readValue(),
+			ShowDesktopNotificationsOption.readValue(),
+		]);
 	}
 });

--- a/extension/options.js
+++ b/extension/options.js
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			RootUrlOption.readValue(),
 			OauthTokenOption.readValue(),
 			UseParticipatingCountOption.readValue(),
-			ShowDesktopNotificationsOption.readValue(),
+			ShowDesktopNotificationsOption.readValue()
 		]);
 	}
 });

--- a/extension/src/api.js
+++ b/extension/src/api.js
@@ -48,7 +48,7 @@ const API = {
 		const status = response.status;
 
 		if (status >= 500) {
-			throw new Error('server error')
+			throw new Error('server error');
 		}
 
 		if (status >= 400) {

--- a/extension/src/api.js
+++ b/extension/src/api.js
@@ -2,17 +2,18 @@ const PersistenceService = require('./persistence-service.js');
 const networkRequest = require('./network-request.js');
 
 const API = {
-	buildQuery(options) {
+	async buildQuery(options) {
 		const params = new window.URLSearchParams();
 		params.append('per_page', options.perPage);
-		if (PersistenceService.get('useParticipatingCount')) {
+		const useParticipating = await PersistenceService.get('useParticipatingCount');
+		if (useParticipating) {
 			params.append('participating', true);
 		}
 		return params.toString();
 	},
 
-	getApiUrl(query) {
-		let rootUrl = PersistenceService.get('rootUrl');
+	async getApiUrl(query) {
+		let rootUrl = await PersistenceService.get('rootUrl');
 
 		if (/(^(https:\/\/)?(api\.)?github\.com)/.test(rootUrl)) {
 			rootUrl = 'https://api.github.com/notifications';
@@ -21,35 +22,37 @@ const API = {
 		}
 
 		if (query) {
-			return `${rootUrl}?${this.buildQuery(query)}`;
+			const params = await this.buildQuery(query);
+			return `${rootUrl}?${params}`;
 		}
 
 		return rootUrl;
 	},
 
-	getTabUrl() {
-		let rootUrl = PersistenceService.get('rootUrl');
+	async getTabUrl() {
+		let rootUrl = await PersistenceService.get('rootUrl');
 
 		if (/api.github.com\/$/.test(rootUrl)) {
 			rootUrl = 'https://github.com/';
 		}
 
 		const tabUrl = `${rootUrl}notifications`;
-		if (PersistenceService.get('useParticipatingCount')) {
+		const useParticipating = await PersistenceService.get('useParticipatingCount');
+		if (useParticipating) {
 			return `${tabUrl}/participating`;
 		}
 		return tabUrl;
 	},
 
-	parseApiResponse(response) {
+	async parseApiResponse(response) {
 		const status = response.status;
 
 		if (status >= 500) {
-			return Promise.reject(new Error('server error'));
+			throw new Error('server error')
 		}
 
 		if (status >= 400) {
-			return Promise.reject(new Error(`client error: ${status} ${response.statusText}`));
+			throw new Error(`client error: ${status} ${response.statusText}`);
 		}
 
 		const interval = Number(response.headers.get('X-Poll-Interval'));
@@ -57,9 +60,8 @@ const API = {
 		const linkheader = response.headers.get('Link');
 
 		if (linkheader === null) {
-			return response.json().then(data => {
-				return {count: data.length, interval, lastModified};
-			});
+			const data = await response.json();
+			return {count: data.length, interval, lastModified};
 		}
 
 		const lastlink = linkheader.split(', ').find(link => {
@@ -67,16 +69,17 @@ const API = {
 		});
 
 		const count = Number(lastlink.slice(lastlink.lastIndexOf('page=') + 5, lastlink.lastIndexOf('>')));
-		return Promise.resolve({count, interval, lastModified});
+		return {count, interval, lastModified};
 	},
 
-	makeApiRequest(options) {
-		const url = options.url || this.getApiUrl(options);
+	async makeApiRequest(options) {
+		const url = options.url ? options.url : await this.getApiUrl(options);
 		return networkRequest(url);
 	},
 
-	getNotifications() {
-		return this.makeApiRequest({perPage: 1}).then(this.parseApiResponse);
+	async getNotifications() {
+		const response = await this.makeApiRequest({perPage: 1});
+		return this.parseApiResponse(response);
 	}
 };
 

--- a/extension/src/network-request.js
+++ b/extension/src/network-request.js
@@ -9,10 +9,10 @@ const getHeaders = token => {
 	/* eslint-enable quote-props */
 };
 
-const request = url => {
-	const token = PersistenceService.get('oauthToken');
+const request = async url => {
+	const token = await PersistenceService.get('oauthToken');
 	if (!token) {
-		return Promise.reject(new Error('missing token'));
+		throw new Error('missing token');
 	}
 
 	const headers = getHeaders(token);

--- a/extension/src/notifications-service.js
+++ b/extension/src/notifications-service.js
@@ -4,8 +4,8 @@ const PersistenceService = require('./persistence-service.js');
 const TabsService = require('./tabs-service.js');
 
 const NotificationsService = {
-	openNotification(notificationId) {
-		const url = PersistenceService.get(notificationId);
+	async openNotification(notificationId) {
+		const url = await PersistenceService.get(notificationId);
 		if (url) {
 			return API.makeApiRequest({url}).then(res => res.json()).then(json => {
 				const tabUrl = json.message === 'Not Found' ? API.getTabUrl() : json.html_url;
@@ -27,10 +27,10 @@ const NotificationsService = {
 		PersistenceService.remove(notificationId);
 	},
 
-	checkNotifications(lastModified) {
-		return API.makeApiRequest({perPage: 100}).then(res => res.json()).then(notifications => {
-			this.showNotifications(notifications, lastModified);
-		});
+	async checkNotifications(lastModified) {
+		const response = await API.makeApiRequest({perPage: 100});
+		const notifications = await response.json();
+		this.showNotifications(notifications, lastModified);
 	},
 
 	getNotificationObject(notificationInfo) {

--- a/extension/src/notifications-service.js
+++ b/extension/src/notifications-service.js
@@ -11,7 +11,7 @@ const NotificationsService = {
 				const json = await API.makeApiRequest({url}).then(res => res.json());
 				const tabUrl = json.message === 'Not Found' ? await API.getTabUrl() : json.html_url;
 				await TabsService.openTab(tabUrl);
-			} catch (e) {
+			} catch (err) {
 				await TabsService.openTab(await API.getTabUrl());
 				return this.closeNotification(notificationId);
 			}

--- a/extension/src/notifications-service.js
+++ b/extension/src/notifications-service.js
@@ -7,9 +7,14 @@ const NotificationsService = {
 	async openNotification(notificationId) {
 		const url = await PersistenceService.get(notificationId);
 		if (url) {
-			const json = await API.makeApiRequest({url}).then(res => res.json());
-			const tabUrl = json.message === 'Not Found' ? await API.getTabUrl() : json.html_url;
-			await TabsService.openTab(tabUrl);
+			try {
+				const json = await API.makeApiRequest({url}).then(res => res.json());
+				const tabUrl = json.message === 'Not Found' ? await API.getTabUrl() : json.html_url;
+				await TabsService.openTab(tabUrl);
+			} catch (e) {
+				await TabsService.openTab(await API.getTabUrl());
+				return this.closeNotification(notificationId);
+			}
 		}
 		return this.closeNotification(notificationId);
 	},
@@ -25,8 +30,7 @@ const NotificationsService = {
 	},
 
 	async checkNotifications(lastModified) {
-		const response = await API.makeApiRequest({perPage: 100});
-		const notifications = await response.json();
+		const notifications = await API.makeApiRequest({perPage: 100}).then(res => res.json());
 		this.showNotifications(notifications, lastModified);
 	},
 

--- a/extension/src/notifications-service.js
+++ b/extension/src/notifications-service.js
@@ -7,12 +7,9 @@ const NotificationsService = {
 	async openNotification(notificationId) {
 		const url = await PersistenceService.get(notificationId);
 		if (url) {
-			return API.makeApiRequest({url}).then(res => res.json()).then(json => {
-				const tabUrl = json.message === 'Not Found' ? API.getTabUrl() : json.html_url;
-				return TabsService.openTab(tabUrl);
-			}).then(() => this.closeNotification(notificationId))
-				.catch(() => TabsService.openTab(API.getTabUrl()))
-				.then(() => this.closeNotification(notificationId));
+			const json = await API.makeApiRequest({url}).then(res => res.json());
+			const tabUrl = json.message === 'Not Found' ? await API.getTabUrl() : json.html_url;
+			await TabsService.openTab(tabUrl);
 		}
 		return this.closeNotification(notificationId);
 	},

--- a/extension/src/option.js
+++ b/extension/src/option.js
@@ -12,15 +12,16 @@ class Option {
 		this.readValue();
 	}
 
-	readValue() {
-		this.element[this.valueType] = PersistenceService.get(this.storageKey);
+	async readValue() {
+		const value = await PersistenceService.get(this.storageKey);
+		this.element[this.valueType] = value;
 	}
 
-	writeValue(override) {
+	async writeValue(override) {
 		if (override) {
 			this.element[this.valueType] = override;
 		}
-		PersistenceService.set(this.storageKey, this.element[this.valueType]);
+		await PersistenceService.set(this.storageKey, this.element[this.valueType]);
 	}
 }
 

--- a/extension/src/persistence-service.js
+++ b/extension/src/persistence-service.js
@@ -3,7 +3,7 @@ const Defaults = require('./defaults.js');
 const PersistenceService = {
 	getItemAsync(name) {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.get(name, (value) => {
+			chrome.storage.sync.get(name, value => {
 				if (chrome.runtime.lastError) {
 					return reject(chrome.runtime.lastError);
 				}
@@ -24,7 +24,7 @@ const PersistenceService = {
 
 	set(name, value) {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.set({[name]:value}, () => {
+			chrome.storage.sync.set({[name]: value}, () => {
 				if (chrome.runtime.lastError) {
 					return reject(chrome.runtime.lastError);
 				}

--- a/extension/src/persistence-service.js
+++ b/extension/src/persistence-service.js
@@ -3,9 +3,9 @@ const Defaults = require('./defaults.js');
 const PersistenceService = {
 	getItemAsync(name) {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.get(name, value => {
-				if (chrome.runtime.lastError) {
-					return reject(chrome.runtime.lastError);
+			window.chrome.storage.sync.get(name, value => {
+				if (window.chrome.runtime.lastError) {
+					return reject(window.chrome.runtime.lastError);
 				}
 				resolve(value);
 			});
@@ -19,14 +19,14 @@ const PersistenceService = {
 			return Defaults.get(name);
 		}
 
-		return item[name];
+		return typeof item === 'object' ? item[name] : item;
 	},
 
 	set(name, value) {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.set({[name]: value}, () => {
-				if (chrome.runtime.lastError) {
-					return reject(chrome.runtime.lastError);
+			window.chrome.storage.sync.set({[name]: value}, () => {
+				if (window.chrome.runtime.lastError) {
+					return reject(window.chrome.runtime.lastError);
 				}
 				resolve();
 			});
@@ -35,9 +35,9 @@ const PersistenceService = {
 
 	remove(name) {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.remove(name, () => {
-				if (chrome.runtime.lastError) {
-					return reject(chrome.runtime.lastError);
+			window.chrome.storage.sync.remove(name, () => {
+				if (window.chrome.runtime.lastError) {
+					return reject(window.chrome.runtime.lastError);
 				}
 				resolve();
 			});
@@ -46,9 +46,9 @@ const PersistenceService = {
 
 	reset() {
 		return new Promise((resolve, reject) => {
-			chrome.storage.sync.reset(name, () => {
-				if (chrome.runtime.lastError) {
-					return reject(chrome.runtime.lastError);
+			window.chrome.storage.sync.reset(() => {
+				if (window.chrome.runtime.lastError) {
+					return reject(window.chrome.runtime.lastError);
 				}
 				resolve();
 			});

--- a/extension/src/persistence-service.js
+++ b/extension/src/persistence-service.js
@@ -1,30 +1,58 @@
 const Defaults = require('./defaults.js');
 
 const PersistenceService = {
-	get(name) {
-		const item = window.localStorage.getItem(name);
+	getItemAsync(name) {
+		return new Promise((resolve, reject) => {
+			chrome.storage.sync.get(name, (value) => {
+				if (chrome.runtime.lastError) {
+					return reject(chrome.runtime.lastError);
+				}
+				resolve(value);
+			});
+		});
+	},
 
-		if (item === null) {
+	async get(name) {
+		const item = await this.getItemAsync(name);
+
+		if (item === null || item === undefined) {
 			return Defaults.get(name);
 		}
 
-		if (item === 'true' || item === 'false') {
-			return item === 'true';
-		}
-
-		return item;
+		return item[name];
 	},
 
 	set(name, value) {
-		window.localStorage.setItem(name, value);
+		return new Promise((resolve, reject) => {
+			chrome.storage.sync.set({[name]:value}, () => {
+				if (chrome.runtime.lastError) {
+					return reject(chrome.runtime.lastError);
+				}
+				resolve();
+			});
+		});
 	},
 
 	remove(name) {
-		window.localStorage.removeItem(name);
+		return new Promise((resolve, reject) => {
+			chrome.storage.sync.remove(name, () => {
+				if (chrome.runtime.lastError) {
+					return reject(chrome.runtime.lastError);
+				}
+				resolve();
+			});
+		});
 	},
 
 	reset() {
-		window.localStorage.clear();
+		return new Promise((resolve, reject) => {
+			chrome.storage.sync.reset(name, () => {
+				if (chrome.runtime.lastError) {
+					return reject(chrome.runtime.lastError);
+				}
+				resolve();
+			});
+		});
 	}
 };
 

--- a/extension/src/tabs-service.js
+++ b/extension/src/tabs-service.js
@@ -38,8 +38,8 @@ const TabsService = {
 			} else if (tab && tab.url === 'chrome://newtab/') {
 				return this.updateTab(null, {url, active: false});
 			}
-			return this.createTab(url);
 		}
+		return this.createTab(url);
 	}
 };
 

--- a/extension/src/tabs-service.js
+++ b/extension/src/tabs-service.js
@@ -29,19 +29,17 @@ const TabsService = {
 		});
 	},
 
-	openTab(url, tab) {
-		return PermissionsService.queryPermission('tabs').then(granted => {
-			if (granted) {
-				return this.queryTabs(url);
-			}
-		}).then(tabs => {
+	async openTab(url, tab) {
+		const granted = await PermissionsService.queryPermission('tabs');
+		if (granted) {
+			const tabs = await this.queryTabs(url);
 			if (tabs && tabs.length > 0) {
 				return this.updateTab(tabs[0].id, {url, active: true});
 			} else if (tab && tab.url === 'chrome://newtab/') {
 				return this.updateTab(null, {url, active: false});
 			}
 			return this.createTab(url);
-		});
+		}
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-preset-es2017": "^6.16.0",
-    "chrome-stub": "^1.3.2",
     "chrome-webstore-upload-cli": "^1.0.3",
     "istanbul": "^0.4.0",
     "moment": "^2.14.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "istanbul": "^0.4.0",
     "moment": "^2.14.1",
     "p-immediate": "^2.1.0",
-    "sinon": "^1.15.4",
+    "sinon": "^2.1.0",
     "url-search-params": "^0.6.1",
     "webpack": "^1.14.0",
     "xo": "*"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
     "babel-plugin-syntax-async-functions": "^6.13.0",
+    "babel-preset-es2017": "^6.16.0",
     "chrome-stub": "^1.3.2",
     "chrome-webstore-upload-cli": "^1.0.3",
     "istanbul": "^0.4.0",
@@ -22,7 +23,11 @@
     "xo": "*"
   },
   "ava": {
-    "files": "test/*-test.*"
+    "files": "test/*-test.*",
+    "require": ["babel-register"]
+  },
+  "babel": {
+    "presets": ["es2017"]
   },
   "xo": {
     "esnext": true,

--- a/package.json
+++ b/package.json
@@ -11,15 +11,14 @@
     "ava": "*",
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
-    "babel-plugin-syntax-async-functions": "^6.13.0",
-    "babel-preset-es2017": "^6.16.0",
+    "babel-preset-env": "^1.3.3",
     "chrome-webstore-upload-cli": "^1.0.3",
     "istanbul": "^0.4.0",
     "moment": "^2.14.1",
     "p-immediate": "^2.1.0",
     "sinon": "^2.1.0",
     "url-search-params": "^0.6.1",
-    "webpack": "^1.14.0",
+    "webpack": "^2.3.3",
     "xo": "*"
   },
   "ava": {
@@ -27,7 +26,9 @@
     "require": ["babel-register"]
   },
   "babel": {
-    "presets": ["es2017"]
+    "presets": [
+      ["env", {"targets": { "chrome": 55 }, "useBuiltIns": true }]
+    ]
   },
   "xo": {
     "esnext": true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": "sindresorhus/notifier-for-github-chrome",
   "scripts": {
     "release": "npm run build && webstore upload --source=extension --auto-publish",
-    "test": "xo && ava",
+    "test": "xo && ava --serial",
     "build": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --watch"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "release": "npm run build && webstore upload --source=extension --auto-publish",
     "test": "xo && ava",
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "build:watch": "webpack --config webpack.config.js --watch"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "scripts": {
     "release": "npm run build && webstore upload --source=extension --auto-publish",
     "test": "xo && ava",
-    "build": "webpack --config"
+    "build": "webpack --config webpack.config.js"
   },
   "devDependencies": {
     "ava": "*",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-plugin-syntax-async-functions": "^6.13.0",
     "chrome-stub": "^1.3.2",
     "chrome-webstore-upload-cli": "^1.0.3",
     "istanbul": "^0.4.0",
@@ -15,7 +18,7 @@
     "p-immediate": "^2.1.0",
     "sinon": "^1.15.4",
     "url-search-params": "^0.6.1",
-    "webpack": "^1.13.2",
+    "webpack": "^1.14.0",
     "xo": "*"
   },
   "ava": {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -24,74 +24,74 @@ test.beforeEach(t => {
 	};
 });
 
-test('#buildQuery respects per_page option', t => {
+test('#buildQuery respects per_page option', async t => {
 	const service = t.context.api;
 
-	t.is(service.buildQuery({perPage: 1}), 'per_page=1');
+	t.is(await service.buildQuery({perPage: 1}), 'per_page=1');
 });
 
-test('#buildQuery respects useParticipatingCount setting', t => {
+test('#buildQuery respects useParticipatingCount setting', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub().returns(true);
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(true);
 
-	t.is(service.buildQuery({perPage: 1}), 'per_page=1&participating=true');
+	t.is(await service.buildQuery({perPage: 1}), 'per_page=1&participating=true');
 });
 
-test('#getApiUrl uses default endpoint if rootUrl matches GitHub', t => {
+test('#getApiUrl uses default endpoint if rootUrl matches GitHub', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub().returns('https://api.github.com/');
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync('https://api.github.com/');
 
-	t.is(service.getApiUrl(), 'https://api.github.com/notifications');
+	t.is(await service.getApiUrl(), 'https://api.github.com/notifications');
 });
 
-test('#getApiUrl uses custom endpoint if rootUrl is something other than GitHub', t => {
+test('#getApiUrl uses custom endpoint if rootUrl is something other than GitHub', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub().returns('https://something.com/');
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync('https://something.com/');
 
-	t.is(service.getApiUrl(), 'https://something.com/api/v3/notifications');
+	t.is(await service.getApiUrl(), 'https://something.com/api/v3/notifications');
 });
 
-test('#getApiUrl uses query if passed', t => {
+test('#getApiUrl uses query if passed', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub();
-	window.localStorage.getItem.withArgs('rootUrl').returns('https://api.github.com/');
-	window.localStorage.getItem.withArgs('useParticipatingCount').returns(false);
+	window.chrome.storage.sync.get = sinon.stub();
+	window.chrome.storage.sync.get.withArgs('rootUrl').yieldsAsync('https://api.github.com/');
+	window.chrome.storage.sync.get.withArgs('useParticipatingCount').yieldsAsync(false);
 
-	t.is(service.getApiUrl({perPage: 123}), 'https://api.github.com/notifications?per_page=123');
+	t.is(await service.getApiUrl({perPage: 123}), 'https://api.github.com/notifications?per_page=123');
 });
 
-test('#getTabUrl uses default page if rootUrl matches GitHub', t => {
+test('#getTabUrl uses default page if rootUrl matches GitHub', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub();
-	window.localStorage.getItem.withArgs('rootUrl').returns('https://api.github.com/');
-	window.localStorage.getItem.withArgs('useParticipatingCount').returns(false);
+	window.chrome.storage.sync.get = sinon.stub();
+	window.chrome.storage.sync.get.withArgs('rootUrl').yieldsAsync('https://api.github.com/');
+	window.chrome.storage.sync.get.withArgs('useParticipatingCount').yieldsAsync(false);
 
-	t.is(service.getTabUrl(), 'https://github.com/notifications');
+	t.is(await service.getTabUrl(), 'https://github.com/notifications');
 });
 
-test('#getTabUrl uses uses custom page if rootUrl is something other than GitHub', t => {
+test('#getTabUrl uses uses custom page if rootUrl is something other than GitHub', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub();
-	window.localStorage.getItem.withArgs('rootUrl').returns('https://something.com/');
-	window.localStorage.getItem.withArgs('useParticipatingCount').returns(false);
+	window.chrome.storage.sync.get = sinon.stub();
+	window.chrome.storage.sync.get.withArgs('rootUrl').yieldsAsync('https://something.com/');
+	window.chrome.storage.sync.get.withArgs('useParticipatingCount').yieldsAsync(false);
 
-	t.is(service.getTabUrl(), 'https://something.com/notifications');
+	t.is(await service.getTabUrl(), 'https://something.com/notifications');
 });
 
-test('#getTabUrl respects useParticipatingCount setting', t => {
+test('#getTabUrl respects useParticipatingCount setting', async t => {
 	const service = t.context.api;
 
-	window.localStorage.getItem = sinon.stub();
-	window.localStorage.getItem.withArgs('rootUrl').returns('https://api.github.com/');
-	window.localStorage.getItem.withArgs('useParticipatingCount').returns(true);
+	window.chrome.storage.sync.get = sinon.stub();
+	window.chrome.storage.sync.get.withArgs('rootUrl').yieldsAsync('https://api.github.com/');
+	window.chrome.storage.sync.get.withArgs('useParticipatingCount').yieldsAsync(true);
 
-	t.is(service.getTabUrl(), 'https://github.com/notifications/participating');
+	t.is(await service.getTabUrl(), 'https://github.com/notifications/participating');
 });
 
 test('#parseApiResponse promise resolves response of 0 notifications if Link header is null', async t => {
@@ -122,7 +122,7 @@ test('#parseApiResponse promise resolves response of N notifications according t
 	t.deepEqual(nextParsedResponse, {count: 3, interval: 60, lastModified: null});
 });
 
-test.serial('#parseApiResponse returns rejected promise for 4xx status codes', t => {
+test('#parseApiResponse returns rejected promise for 4xx status codes', t => {
 	const service = t.context.api;
 	const resp = t.context.getDefaultResponse({
 		status: 404,
@@ -132,7 +132,7 @@ test.serial('#parseApiResponse returns rejected promise for 4xx status codes', t
 	t.throws(service.parseApiResponse(resp), 'client error: 404 Not found');
 });
 
-test('#parseApiResponse returns rejected promise for 5xx status codes', t => {
+test('#parseApiResponse returns rejected promise for 5xx status codes', async t => {
 	const service = t.context.api;
 	const resp = t.context.getDefaultResponse({
 		status: 500
@@ -141,34 +141,34 @@ test('#parseApiResponse returns rejected promise for 5xx status codes', t => {
 	t.throws(service.parseApiResponse(resp), 'server error');
 });
 
-test('#makeApiRequest makes networkRequest for provided url', t => {
+test('#makeApiRequest makes networkRequest for provided url', async t => {
 	const service = t.context.api;
 	const url = 'https://api.github.com/resource';
 
 	window.fetch = sinon.stub().returns(Promise.resolve('response'));
-	window.localStorage.getItem = sinon.stub().returns('token');
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync('token');
 
-	service.makeApiRequest({url});
+	await service.makeApiRequest({url});
 
 	t.true(window.fetch.calledWith(url));
 });
 
-test('#makeApiRequest makes networkRequest to #getApiUrl if no url provided in options', t => {
+test('#makeApiRequest makes networkRequest to #getApiUrl if no url provided in options', async t => {
 	const service = t.context.api;
 	const url = 'https://api.github.com/resource';
 
 	window.fetch = sinon.stub().returns(Promise.resolve('response'));
-	window.localStorage.getItem = sinon.stub().returns('token');
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync('token');
 
-	service.makeApiRequest({url});
+	await service.makeApiRequest({url});
 
 	t.true(window.fetch.calledWith(url));
 });
 
 test('#getNotifications returns promise that resolves to parsed API response', async t => {
 	const service = t.context.api;
-	service.getApiUrl = sinon.stub().returns('https://api.github.com/resource');
 
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync('token');
 	window.fetch = sinon.stub().returns(Promise.resolve(t.context.getDefaultResponse()));
 
 	service.makeApiRequest = sinon.spy(service, 'makeApiRequest');

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -14,19 +14,20 @@ test.beforeEach(t => {
 		const headers = new Map([
 			['X-Poll-Interval', '60'],
 			['Last-Modified', null],
-			['Link', null],
+			['Link', null]
 		]);
 		return Object.assign({
 			status: 200,
-			headers: headers,
+			headers,
 			json: () => Promise.resolve([])
 		}, overrides);
 	};
 
-	window.chrome.storage.sync = { get: () => {} };
+	window.chrome.storage.sync = {get: () => {}};
+	sandbox.stub(window, 'fetch');
 });
 
-test.afterEach(t => {
+test.afterEach(() => {
 	sandbox.restore();
 });
 
@@ -160,12 +161,8 @@ test('#parseApiResponse returns rejected promise for 5xx status codes', async t 
 test('#makeApiRequest makes networkRequest for provided url', async t => {
 	const service = t.context.api;
 	const url = 'https://api.github.com/resource';
-	let calls = 0;
 
-	window.fetch = () => {
-		calls += 1;
-		return Promise.resolve('response');
-	};
+	window.fetch.returns(Promise.resolve('response'));
 
 	sandbox.stub(window.chrome.storage.sync, 'get')
 		.withArgs('useParticipatingCount').yieldsAsync(false)
@@ -173,31 +170,29 @@ test('#makeApiRequest makes networkRequest for provided url', async t => {
 
 	await service.makeApiRequest({url});
 
-	t.is(calls, 1);
+	t.true(window.fetch.calledOnce);
 });
 
 test('#makeApiRequest makes networkRequest to #getApiUrl if no url provided in options', async t => {
 	const service = t.context.api;
 	const url = 'https://api.github.com/resource';
-	let calls = 0;
 
-	window.fetch = () => {
-		calls += 1;
-		return Promise.resolve('response');
-	};
+	window.fetch.returns(Promise.resolve('response'));
+
 	sandbox.stub(window.chrome.storage.sync, 'get')
 		.withArgs('useParticipatingCount').yieldsAsync(false)
 		.withArgs('oauthToken').yieldsAsync('token');
 
 	await service.makeApiRequest({url});
 
-	t.is(calls, 1);
+	t.true(window.fetch.calledOnce);
 });
 
 test('#getNotifications returns promise that resolves to parsed API response', async t => {
 	const service = t.context.api;
 
-	window.fetch = () => { return Promise.resolve(t.context.getDefaultResponse()) }
+	window.fetch.returns(Promise.resolve(t.context.getDefaultResponse()));
+
 	sandbox.stub(window.chrome.storage.sync, 'get')
 		.withArgs('useParticipatingCount').yieldsAsync(false)
 		.withArgs('rootUrl').yieldsAsync('https://api.github.com/')

--- a/test/network-request-test.js
+++ b/test/network-request-test.js
@@ -9,11 +9,10 @@ const networkRequest = require('../extension/src/network-request.js');
 
 test.beforeEach(t => {
 	t.context.endpoint = 'http://endpoint.net/foo';
-	window.chrome.storage.sync = { get: () => {} };
-	window.fetch = () => {};
+	window.chrome.storage.sync = {get: () => {}};
 });
 
-test.afterEach(t => {
+test.afterEach(() => {
 	sandbox.restore();
 });
 

--- a/test/network-request-test.js
+++ b/test/network-request-test.js
@@ -3,16 +3,25 @@ import sinon from 'sinon';
 import util from './util';
 
 global.window = util.setupWindow();
+const sandbox = sinon.sandbox.create();
 
 const networkRequest = require('../extension/src/network-request.js');
 
 test.beforeEach(t => {
 	t.context.endpoint = 'http://endpoint.net/foo';
+	window.chrome.storage.sync = { get: () => {} };
+	window.fetch = () => {};
+});
+
+test.afterEach(t => {
+	sandbox.restore();
 });
 
 test('#request returns Promise', async t => {
-	window.fetch = sinon.stub().returns(Promise.resolve('{}'));
-	window.localStorage.getItem = sinon.stub().returns('oauthToken');
+	sandbox.stub(window, 'fetch').returns(Promise.resolve('{}'));
+
+	sandbox.stub(window.chrome.storage.sync, 'get')
+		.withArgs('oauthToken').yieldsAsync('token');
 
 	const response = await networkRequest(t.context.endpoint);
 
@@ -20,8 +29,10 @@ test('#request returns Promise', async t => {
 });
 
 test('#request requests fetches given url with proper headers', async t => {
-	window.fetch = sinon.stub().returns(Promise.resolve('{}'));
-	window.localStorage.getItem = sinon.stub().returns('oauthToken');
+	sandbox.stub(window, 'fetch').returns(Promise.resolve('{}'));
+
+	sandbox.stub(window.chrome.storage.sync, 'get')
+		.withArgs('oauthToken').yieldsAsync('oauthToken');
 
 	const response = await networkRequest(t.context.endpoint);
 	const args = [t.context.endpoint, {
@@ -37,8 +48,9 @@ test('#request requests fetches given url with proper headers', async t => {
 	t.is(response, '{}');
 });
 
-test('#request returns rejected Promise if oauthToken is empty', t => {
-	window.localStorage.getItem = sinon.stub().returns('');
+test('#request returns rejected Promise if oauthToken is empty', async t => {
+	sandbox.stub(window.chrome.storage.sync, 'get')
+		.withArgs('oauthToken').yieldsAsync('');
 
-	t.throws(networkRequest(t.context.endpoint), 'missing token');
+	await t.throws(networkRequest(t.context.endpoint), 'missing token');
 });

--- a/test/notifications-service-test.js
+++ b/test/notifications-service-test.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import sinon from 'sinon';
 import moment from 'moment';
-import util from './util';
 import pImmediate from 'p-immediate';
+import util from './util';
 
 global.window = util.setupWindow();
 const sandbox = sinon.sandbox.create();
@@ -27,7 +27,7 @@ test.beforeEach(t => {
 		}
 	};
 
-	window.chrome.storage.sync = { get() {}, remove() {}, set() {} };
+	window.chrome.storage.sync = {get() {}, remove() {}, set() {}};
 
 	sandbox.stub(window.chrome.storage.sync, 'get')
 		.withArgs('useParticipatingCount').yieldsAsync(false)
@@ -35,10 +35,9 @@ test.beforeEach(t => {
 		.withArgs('oauthToken').yieldsAsync('token');
 	sandbox.stub(window.chrome.storage.sync, 'set').yieldsAsync();
 
-	window.fetch = () => {};
-	window.chrome.tabs = { create() {}, query() {}, clear() {} };
-	window.chrome.notifications = { clear() {}, create() {} };
-	window.chrome.permissions = { contains() {} };
+	window.chrome.tabs = {create() {}, query() {}, clear() {}};
+	window.chrome.notifications = {clear() {}, create() {}};
+	window.chrome.permissions = {contains() {}};
 
 	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window.chrome.notifications, 'clear').yieldsAsync();
@@ -47,7 +46,7 @@ test.beforeEach(t => {
 	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
 });
 
-test.afterEach(t => {
+test.afterEach(() => {
 	sandbox.restore();
 });
 
@@ -79,7 +78,6 @@ test('#openNotification clears notification from queue by notificationId', async
 
 test('#openNotification skips network requests if no url returned by PersistenceService', async t => {
 	const service = t.context.service;
-
 
 	window.chrome.storage.sync.get
 		.withArgs(t.context.notificationId).yieldsAsync(null);

--- a/test/notifications-service-test.js
+++ b/test/notifications-service-test.js
@@ -40,9 +40,11 @@ test.beforeEach(t => {
 	window.chrome.notifications = { clear() {}, create() {} };
 	window.chrome.permissions = { contains() {} };
 
+	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window.chrome.notifications, 'clear').yieldsAsync();
 	sandbox.stub(window.chrome.notifications, 'create');
 	sandbox.stub(window.chrome.tabs, 'create').yieldsAsync();
+	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
 });
 
 test.afterEach(t => {
@@ -52,9 +54,6 @@ test.afterEach(t => {
 test('#openNotification gets notification url by notificationId from PersistenceService', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window, 'fetch').returns(Promise.resolve(t.context.defaultResponse));
 
 	window.chrome.storage.sync.get
@@ -68,8 +67,6 @@ test('#openNotification gets notification url by notificationId from Persistence
 test('#openNotification clears notification from queue by notificationId', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window, 'fetch').returns(Promise.resolve(t.context.defaultResponse));
 
 	window.chrome.storage.sync.get
@@ -83,8 +80,6 @@ test('#openNotification clears notification from queue by notificationId', async
 test('#openNotification skips network requests if no url returned by PersistenceService', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 
 	window.chrome.storage.sync.get
 		.withArgs(t.context.notificationId).yieldsAsync(null);
@@ -97,9 +92,6 @@ test('#openNotification skips network requests if no url returned by Persistence
 
 test('#openNotification closes notification if no url returned by PersistenceService', async t => {
 	const service = t.context.service;
-
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 
 	window.chrome.storage.sync.get
 		.withArgs(t.context.notificationId).yieldsAsync(null);
@@ -114,8 +106,6 @@ test('#openNotification closes notification if no url returned by PersistenceSer
 test('#openNotification opens tab with url from network response', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window, 'fetch').returns(Promise.resolve(t.context.defaultResponse));
 
 	window.chrome.storage.sync.get
@@ -129,8 +119,6 @@ test('#openNotification opens tab with url from network response', async t => {
 test('#openNotification closes notification on error', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window, 'fetch').returns(Promise.reject(new Error('error')));
 
 	window.chrome.storage.sync.get
@@ -144,8 +132,6 @@ test('#openNotification closes notification on error', async t => {
 test('#openNotification opens nofifications tab on error', async t => {
 	const service = t.context.service;
 
-	sandbox.stub(window.chrome.tabs, 'query').yieldsAsync([]);
-	sandbox.stub(window.chrome.permissions, 'contains').yieldsAsync(true);
 	sandbox.stub(window, 'fetch').returns(Promise.reject(new Error('error')));
 
 	window.chrome.storage.sync.get

--- a/test/notifications-service-test.js
+++ b/test/notifications-service-test.js
@@ -33,7 +33,7 @@ test.beforeEach(t => {
 	window.localStorage.getItem.withArgs('oauthToken').returns('token');
 });
 
-test.serial('#openNotification gets notification url by notificationId from PersistenceService', async t => {
+test('#openNotification gets notification url by notificationId from PersistenceService', async t => {
 	const service = t.context.service;
 
 	window.chrome.permissions.contains = sinon.stub().yieldsAsync(true);
@@ -59,7 +59,7 @@ test('#openNotification clears notification from queue by notificationId', async
 	t.true(window.chrome.notifications.clear.calledWithMatch(t.context.notificationId));
 });
 
-test.serial('#openNotification skips network requests if no url returned by PersistenceService', async t => {
+test('#openNotification skips network requests if no url returned by PersistenceService', async t => {
 	const service = t.context.service;
 
 	window.localStorage.getItem = sinon.stub().returns(null);
@@ -120,7 +120,7 @@ test('#openNotification opens nofifications tab on error', async t => {
 	t.true(window.chrome.tabs.create.calledWith({url: 'root/notifications'}));
 });
 
-test.serial('#closeNotification returns promise and clears notifications by id', async t => {
+test('#closeNotification returns promise and clears notifications by id', async t => {
 	const service = t.context.service;
 	const id = t.context.notificationId;
 

--- a/test/option-test.js
+++ b/test/option-test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import util from './util';
 
 global.window = util.setupWindow();
+const sandbox = sinon.sandbox.create();
 
 const PersistenceService = require('../extension/src/persistence-service.js');
 const Option = require('../extension/src/option.js');
@@ -25,29 +26,37 @@ test.beforeEach(t => {
 		onChange() {}
 	};
 	t.context.option = new Option(t.context.optionParams);
+	window.chrome.storage.sync = { get: () => {} };
 });
 
-test('#readValue reads value from PersistenceService', t => {
+test.afterEach(t => {
+	sandbox.restore();
+});
+
+test('#readValue reads value from PersistenceService', async t => {
 	window.localStorage.getItem = sinon.stub().returns('value');
 
-	t.context.option.readValue();
+	sandbox.stub(window.chrome.storage.sync, 'get')
+		.withArgs('key').yieldsAsync('value');
 
-	t.true(window.localStorage.getItem.calledWith('key'));
+	await t.context.option.readValue();
+
+	t.true(window.chrome.storage.sync.get.calledWith('key'));
 	t.is(t.context.option.element.value, 'value');
 });
 
-test('#writeValue writes value to PersistenceService', t => {
+test('#writeValue writes value to PersistenceService', async t => {
 	PersistenceService.set = sinon.stub();
 	t.context.option.element.value = 'value';
-	t.context.option.writeValue();
+	await t.context.option.writeValue();
 
 	t.true(PersistenceService.set.calledWith('key', 'value'));
 });
 
-test('#writeValue respects override', t => {
+test('#writeValue respects override', async t => {
 	PersistenceService.set = sinon.stub();
 	t.context.option.element.value = 'defaultValue';
-	t.context.option.writeValue('newValue');
+	await t.context.option.writeValue('newValue');
 
 	t.true(PersistenceService.set.calledWith('key', 'newValue'));
 	t.is(t.context.option.element.value, 'newValue');

--- a/test/option-test.js
+++ b/test/option-test.js
@@ -25,8 +25,8 @@ test.beforeEach(t => {
 		valueType: 'value',
 		onChange() {}
 	};
+	window.chrome.storage.sync = {get() {}, set() {}};
 	t.context.option = new Option(t.context.optionParams);
-	window.chrome.storage.sync = {get: () => {}};
 });
 
 test.afterEach(() => {

--- a/test/option-test.js
+++ b/test/option-test.js
@@ -26,10 +26,10 @@ test.beforeEach(t => {
 		onChange() {}
 	};
 	t.context.option = new Option(t.context.optionParams);
-	window.chrome.storage.sync = { get: () => {} };
+	window.chrome.storage.sync = {get: () => {}};
 });
 
-test.afterEach(t => {
+test.afterEach(() => {
 	sandbox.restore();
 });
 

--- a/test/permissions-service-test.js
+++ b/test/permissions-service-test.js
@@ -11,6 +11,7 @@ const PermissionsService = require('../extension/src/permissions-service.js');
 test.beforeEach(t => {
 	t.context.service = Object.assign({}, PermissionsService);
 	window.chrome.permissions = {request() {}, contains() {}};
+	window.chrome.storage.sync = {get() {}, set() {}};
 	sandbox.stub(window.chrome.permissions, 'request');
 	sandbox.stub(window.chrome.permissions, 'contains');
 });

--- a/test/permissions-service-test.js
+++ b/test/permissions-service-test.js
@@ -64,7 +64,7 @@ test('#queryPermission returns Promise', async t => {
 	t.pass();
 });
 
-test.serial('#queryPermission Promise resolves to chrome.permissions.request callback value', async t => {
+test('#queryPermission Promise resolves to chrome.permissions.request callback value', async t => {
 	const service = t.context.service;
 
 	window.chrome.permissions.contains = sinon.stub().yieldsAsync(true);

--- a/test/persistence-service-test.js
+++ b/test/persistence-service-test.js
@@ -3,18 +3,25 @@ import sinon from 'sinon';
 import util from './util';
 
 global.window = util.setupWindow();
+const sandbox = sinon.sandbox.create();
 
 const PersistenceService = require('../extension/src/persistence-service.js');
 const Defaults = require('../extension/src/defaults.js');
 
 test.beforeEach(t => {
 	t.context.persistence = Object.assign({}, PersistenceService);
+	window.chrome.storage.sync = {get() {}, set() {}, reset() {}, remove() {}};
+});
+
+test.afterEach(() => {
+	sandbox.restore();
 });
 
 test('#get calls chrome.storage.sync#get', async t => {
 	const service = t.context.persistence;
 
-	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
+	sandbox.stub(window.chrome.storage.sync, 'get').yieldsAsync(null);
+
 	await service.get('name');
 
 	t.true(window.chrome.storage.sync.get.calledWith('name'));
@@ -23,7 +30,7 @@ test('#get calls chrome.storage.sync#get', async t => {
 test('#get looks up in defaults if item is null', async t => {
 	const service = t.context.persistence;
 
-	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
+	sandbox.stub(window.chrome.storage.sync, 'get').yieldsAsync(null);
 
 	t.is(await service.get('rootUrl'), Defaults.get('rootUrl'));
 });
@@ -31,14 +38,15 @@ test('#get looks up in defaults if item is null', async t => {
 test('#get returns undefined if no item found in defaults', async t => {
 	const service = t.context.persistence;
 
-	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
+	sandbox.stub(window.chrome.storage.sync, 'get').yieldsAsync(null);
 
 	t.is(await service.get('no such thing'), undefined);
 });
 
 test('#set calls chrome.storage.sync#set', async t => {
 	const service = t.context.persistence;
-	window.chrome.storage.sync.set = sinon.stub().yieldsAsync();
+
+	sandbox.stub(window.chrome.storage.sync, 'set').yieldsAsync();
 
 	const obj = {value: 42};
 	await service.set('name', obj);
@@ -49,7 +57,8 @@ test('#set calls chrome.storage.sync#set', async t => {
 test('#reset calls window.chrome.storage.sync#reset', async t => {
 	const service = t.context.persistence;
 
-	window.chrome.storage.sync.reset = sinon.stub().yieldsAsync();
+	sandbox.stub(window.chrome.storage.sync, 'reset').yieldsAsync();
+
 	await service.reset();
 
 	t.true(window.chrome.storage.sync.reset.called);
@@ -58,7 +67,8 @@ test('#reset calls window.chrome.storage.sync#reset', async t => {
 test('#remove calls chrome.storage.sync#remove', async t => {
 	const service = t.context.persistence;
 
-	window.chrome.storage.sync.remove = sinon.stub().yieldsAsync();
+	sandbox.stub(window.chrome.storage.sync, 'remove').yieldsAsync();
+
 	await service.remove('name');
 
 	t.true(global.window.chrome.storage.sync.remove.calledWith('name'));

--- a/test/persistence-service-test.js
+++ b/test/persistence-service-test.js
@@ -11,65 +11,55 @@ test.beforeEach(t => {
 	t.context.persistence = Object.assign({}, PersistenceService);
 });
 
-test('#get calls localStorage#getItem', t => {
+test.serial('#get calls chrome.storage.sync#get', async t => {
 	const service = t.context.persistence;
 
-	window.localStorage.getItem = sinon.spy();
-	service.get('name');
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
+	await service.get('name');
 
-	t.true(window.localStorage.getItem.calledWith('name'));
+	t.true(window.chrome.storage.sync.get.calledWith('name'));
 });
 
-test('#get converts "true" and "false" strings to booleans', t => {
+test('#get looks up in defaults if item is null', async t => {
 	const service = t.context.persistence;
 
-	window.localStorage.getItem = sinon.stub().returns('true');
-	t.true(service.get('boolean'));
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
 
-	window.localStorage.getItem = sinon.stub().returns('false');
-	t.false(service.get('boolean'));
+	t.is(await service.get('rootUrl'), Defaults.get('rootUrl'));
 });
 
-test('#get looks up in defaults if item is null', t => {
+test('#get returns undefined if no item found in defaults', async t => {
 	const service = t.context.persistence;
 
-	window.localStorage.getItem = sinon.stub().returns(null);
+	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);
 
-	t.is(service.get('rootUrl'), Defaults.get('rootUrl'));
+	t.is(await service.get('no such thing'), undefined);
 });
 
-test('#get returns undefined if no item found in defaults', t => {
+test('#set calls chrome.storage.sync#set', async t => {
 	const service = t.context.persistence;
-
-	window.localStorage.getItem = sinon.stub().returns(null);
-
-	t.is(service.get('no such thing'), undefined);
-});
-
-test('#set calls localStorage#set', t => {
-	const service = t.context.persistence;
-	window.localStorage.setItem = sinon.spy();
+	window.chrome.storage.sync.set = sinon.stub().yieldsAsync();
 
 	const obj = {value: 42};
-	service.set('name', obj);
+	await service.set('name', obj);
 
-	t.true(window.localStorage.setItem.calledWith('name', obj));
+	t.true(window.chrome.storage.sync.set.calledWith({name: obj}));
 });
 
-test('#reset calls localStorage#clear', t => {
+test('#reset calls window.chrome.storage.sync#reset', async t => {
 	const service = t.context.persistence;
 
-	window.localStorage.clear = sinon.spy();
-	service.reset();
+	window.chrome.storage.sync.reset = sinon.stub().yieldsAsync();
+	await service.reset();
 
-	t.true(window.localStorage.clear.called);
+	t.true(window.chrome.storage.sync.reset.called);
 });
 
-test('#remove calls localStorage#removeItem', t => {
+test('#remove calls chrome.storage.sync#remove', async t => {
 	const service = t.context.persistence;
 
-	window.localStorage.removeItem = sinon.spy();
-	service.remove('name');
+	window.chrome.storage.sync.remove = sinon.stub().yieldsAsync();
+	await service.remove('name');
 
-	t.true(global.window.localStorage.removeItem.calledWith('name'));
+	t.true(global.window.chrome.storage.sync.remove.calledWith('name'));
 });

--- a/test/persistence-service-test.js
+++ b/test/persistence-service-test.js
@@ -11,7 +11,7 @@ test.beforeEach(t => {
 	t.context.persistence = Object.assign({}, PersistenceService);
 });
 
-test.serial('#get calls chrome.storage.sync#get', async t => {
+test('#get calls chrome.storage.sync#get', async t => {
 	const service = t.context.persistence;
 
 	window.chrome.storage.sync.get = sinon.stub().yieldsAsync(null);

--- a/test/util.js
+++ b/test/util.js
@@ -4,6 +4,7 @@ const URLSearchParams = require('url-search-params');
 module.exports = {
 	setupWindow: () => {
 		return {
+			fetch() {},
 			URLSearchParams,
 			localStorage: {
 				setItem: () => {},

--- a/test/util.js
+++ b/test/util.js
@@ -1,4 +1,3 @@
-const chromeStub = require('chrome-stub');
 const URLSearchParams = require('url-search-params');
 
 module.exports = {
@@ -12,9 +11,13 @@ module.exports = {
 				removeItem: () => {}
 			},
 			chrome: Object.assign({}, {
+				browserAction: {},
 				runtime: {},
-				notifications: {}
-			}, chromeStub)
+				notifications: {},
+				tabs: {},
+				permissions: {},
+				storage: {}
+			})
 		};
 	}
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,19 @@
+const path = require('path');
+
 module.exports = {
 	entry: {
 		main: './extension/main.js',
 		options: './extension/options.js'
 	},
 	output: {
-		path: './extension/dist',
+		path: path.resolve(__dirname, './extension/dist'),
 		filename: '[name].js',
-		publicPath: ''
 	},
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /\.js$/,
-				loader: 'babel-loader',
-				query: {
-					plugins: ['syntax-async-functions']
-				}
+				use: ['babel-loader']
 			}
 		]
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,5 +7,16 @@ module.exports = {
 		path: './extension/dist',
 		filename: '[name].js',
 		publicPath: ''
+	},
+	module: {
+		loaders: [
+			{
+				test: /\.js$/,
+				loader: 'babel-loader',
+				query: {
+					"plugins": ["syntax-async-functions"]
+				}
+			}
+		]
 	}
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 				test: /\.js$/,
 				loader: 'babel-loader',
 				query: {
-					"plugins": ["syntax-async-functions"]
+					plugins: ['syntax-async-functions']
 				}
 			}
 		]


### PR DESCRIPTION
Fixes #39 
Also uses async/await and bumps chrome version to 55 to have native async/await support.
Babel is only needed to make it possible for webpack to get build passing because of async/await syntax, no transpilation should occur.
- [x] Fix tests
- [ ] Implement migrator
- [ ] Tests for migrator

Any comments are welcome.