### PR TITLE
Support Firefox

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -17,6 +17,9 @@
 				font-style: italic;
 				color: grey;
 			}
+			span#notifications-permission-error {
+				color: red;
+			}
 		</style>
 		<script defer src="dist/options.js"></script>
 	</head>
@@ -42,7 +45,8 @@
 		<section>
  			<h3>Desktop Notifications</h3>
  			<input type="checkbox" id="show_desktop_notif">
- 			<label for="show_desktop_notif">Show desktop notifications</label>
+			 <label for="show_desktop_notif">Show desktop notifications</label>
+			 <span id="notifications-permission-error" style="display: none" role="alert">Could not request notifications permission. If you are using Firefox, open <a href="options.html">this page</a> in a new tab and try again.</span>
  		</section>
 	</body>
 </html>

--- a/extension/options.html
+++ b/extension/options.html
@@ -45,8 +45,8 @@
 		<section>
  			<h3>Desktop Notifications</h3>
  			<input type="checkbox" id="show_desktop_notif">
-			 <label for="show_desktop_notif">Show desktop notifications</label>
-			 <span id="notifications-permission-error" style="display: none" role="alert">Could not request notifications permission. If you are using Firefox, open <a href="options.html">this page</a> in a new tab and try again.</span>
+			<label for="show_desktop_notif">Show desktop notifications</label>
+			<span id="notifications-permission-error" style="display: none" role="alert">Could not request notifications permission. If you are using Firefox, open <a href="options.html">this page</a> in a new tab and try again.</span>
  		</section>
 	</body>
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -60,6 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					}
 
 					option.writeValue(granted);
+				}).catch(() => {
+					// Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1382953
+					document.getElementById('notifications-permission-error').style.display = 'block';
 				});
 			} else {
 				option.writeValue();


### PR DESCRIPTION
The only issue I've found is that optional permissions can be requested only if `options.html` is opened in a new tab (https://bugzilla.mozilla.org/show_bug.cgi?id=1382953). This fixes it by displaying an error message so that the user can work around the issue.

Close https://github.com/sindresorhus/notifier-for-github-chrome/issues/135
Close https://github.com/sindresorhus/notifier-for-github-chrome/issues/118