### PR TITLE
Remove redundant permissions from the manifest

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -10,14 +10,11 @@
 	},
 	"permissions": [
 		"alarms",
-		"storage",
-		"contextMenus"
+		"storage"
 	],
 	"optional_permissions": [
 		"tabs",
-		"notifications",
-		"http://*/*",
-		"https://*/*"
+		"notifications"
 	],
 	"background": {
 		"persistent": false,


### PR DESCRIPTION
Removes redundant or unnecessary permissions from the manifest.

Context: https://github.com/sindresorhus/notifier-for-github/issues/155#issuecomment-408549525, https://github.com/sindresorhus/notifier-for-github/issues/155#issuecomment-408590709