### PR TITLE
Option: Always open notification page in new tab

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -14,7 +14,8 @@ new OptionsSync().define({
 		rootUrl: 'https://api.github.com/',
 		playNotifSound: false,
 		showDesktopNotif: false,
-		onlyParticipating: false
+		onlyParticipating: false,
+		newTabAlways: false
 	},
 	migrations: [
 		OptionsSync.migrations.removeUnused
@@ -79,16 +80,19 @@ async function update() {
 }
 
 const handleBrowserActionClick = async () => {
-	const alreadyGranted = await queryPermission('tabs');
+	const {newTabAlways} = await syncStore.getAll();
+	if (!newTabAlways) {
+		const alreadyGranted = await queryPermission('tabs');
 
-	if (!alreadyGranted) {
-		try {
-			const granted = await requestPermission('tabs');
-			if (!granted) {
+		if (!alreadyGranted) {
+			try {
+				const granted = await requestPermission('tabs');
+				if (!granted) {
+					return;
+				}
+			} catch (error) {
 				return;
 			}
-		} catch (error) {
-			return;
 		}
 	}
 

--- a/source/lib/tabs-service.js
+++ b/source/lib/tabs-service.js
@@ -1,4 +1,7 @@
+import OptionsSync from 'webext-options-sync';
 import {queryPermission} from './permissions-service';
+
+const syncStore = new OptionsSync();
 
 export const createTab = async url => {
 	if (browser.runtime.lastError) {
@@ -26,6 +29,10 @@ export const queryTabs = async url => {
 };
 
 export const openTab = async (url, tab) => {
+	const {newTabAlways} = await syncStore.getAll();
+	if (newTabAlways === true) {
+		return createTab(url);
+	}
 	if (await queryPermission('tabs')) {
 		const tabs = await queryTabs(url);
 

--- a/source/options.html
+++ b/source/options.html
@@ -50,6 +50,16 @@
 			Enable notification sound
 		</label>
 	</section>
+
+	<hr>
+
+	<section>
+		<h3>Tab handling</h3>
+		<label>
+			<input type="checkbox" name="newTabAlways">
+			Always open notification page in new tab
+		</label>
+	</section>
 </form>
 
 <script src="browser-polyfill.min.js"></script>


### PR DESCRIPTION
If activated, the extension doesn't need the `tabs` permission (because there is no need to filter the tabs based on the url anymore).

See https://github.com/sindresorhus/notifier-for-github/issues/155#issuecomment-408634428 and following.