### PR TITLE
Jump to last unread comment

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -110,11 +110,6 @@ async function addNotificationHandler() {
 		browser.notifications.onClicked.addListener(id => {
 			openNotification(id);
 		});
-
-		// Possbily broken in browser, event listener getting fired if not displayed to user
-		// browser.notifications.onClosed.addListener(id => {
-		// 	removeNotification(id);
-		// });
 	}
 }
 

--- a/source/background.js
+++ b/source/background.js
@@ -4,7 +4,7 @@ import {openTab} from './lib/tabs-service';
 import {queryPermission} from './lib/permissions-service';
 import {getNotificationCount, getTabUrl} from './lib/api';
 import {renderCount, renderError, renderWarning} from './lib/badge';
-import {checkNotifications, openNotification, removeNotification} from './lib/notifications-service';
+import {checkNotifications, openNotification} from './lib/notifications-service';
 
 const syncStore = new OptionsSync();
 
@@ -22,7 +22,7 @@ new OptionsSync().define({
 	]
 });
 
-const scheduleAlaram = interval => {
+function scheduleNextAlarm(interval) {
 	const intervalSetting = localStore.get('interval') || 60;
 	const intervalValue = interval || 60;
 
@@ -34,43 +34,45 @@ const scheduleAlaram = interval => {
 	const delayInMinutes = Math.max(Math.ceil(intervalValue / 60), 1);
 
 	browser.alarms.create({delayInMinutes});
-};
+}
 
-const handleLastModified = async date => {
+async function handleLastModified(newLastModified) {
 	const lastModified = await localStore.get('lastModified') || new Date(0);
 
-	if (date !== lastModified) {
-		localStore.set('lastModified', date);
+	// Something has changed since we last accessed, display any new notificaitons
+	if (newLastModified !== lastModified) {
 		const {showDesktopNotif, playNotifSound} = await syncStore.getAll();
 		if (showDesktopNotif === true || playNotifSound === true) {
-			checkNotifications(lastModified);
+			await checkNotifications(lastModified);
 		}
-	}
-};
 
-const handleNotificationsResponse = response => {
+		await localStore.set('lastModified', newLastModified);
+	}
+}
+
+async function updateNotificationCount() {
+	const response = await getNotificationCount();
 	const {count, interval, lastModified} = response;
 
-	scheduleAlaram(interval);
-	handleLastModified(lastModified);
-
 	renderCount(count);
-};
+	scheduleNextAlarm(interval);
+	handleLastModified(lastModified);
+}
 
-const handleError = error => {
-	scheduleAlaram();
+function handleError(error) {
+	scheduleNextAlarm();
 
 	renderError(error);
-};
+}
 
-const handleOfflineStatus = () => {
+function handleOfflineStatus() {
 	renderWarning('offline');
-};
+}
 
 async function update() {
 	if (navigator.onLine) {
 		try {
-			handleNotificationsResponse(await getNotificationCount());
+			updateNotificationCount();
 		} catch (error) {
 			handleError(error);
 		}
@@ -79,9 +81,9 @@ async function update() {
 	}
 }
 
-const handleBrowserActionClick = async () => {
+async function handleBrowserActionClick() {
 	await openTab(await getTabUrl());
-};
+}
 
 function handleInstalled(details) {
 	if (details.reason === 'install') {
@@ -89,24 +91,19 @@ function handleInstalled(details) {
 	}
 }
 
-function handleConnectionStatus(event) {
-	if (event.type === 'online') {
+function handleConnectionStatus() {
+	if (navigator.onLine) {
 		update();
-	} else if (event.type === 'offline') {
+	} else {
 		handleOfflineStatus();
 	}
 }
 
-window.addEventListener('online', handleConnectionStatus);
-window.addEventListener('offline', handleConnectionStatus);
-
-browser.alarms.create({when: Date.now() + 2000});
-browser.alarms.onAlarm.addListener(update);
-browser.runtime.onMessage.addListener(message => {
+function onMessage(message) {
 	if (message === 'update') {
 		update();
 	}
-});
+}
 
 async function addNotificationHandler() {
 	if (await queryPermission('notifications')) {
@@ -114,16 +111,29 @@ async function addNotificationHandler() {
 			openNotification(id);
 		});
 
-		browser.notifications.onClosed.addListener(id => {
-			removeNotification(id);
-		});
+		// Possbily broken in browser, event listener getting fired if not displayed to user
+		// browser.notifications.onClosed.addListener(id => {
+		// 	removeNotification(id);
+		// });
 	}
 }
 
-addNotificationHandler();
+function init() {
+	window.addEventListener('online', handleConnectionStatus);
+	window.addEventListener('offline', handleConnectionStatus);
 
-browser.permissions.onAdded.addListener(addNotificationHandler);
-browser.runtime.onInstalled.addListener(handleInstalled);
-browser.browserAction.onClicked.addListener(handleBrowserActionClick);
+	browser.alarms.onAlarm.addListener(update);
+	browser.alarms.create({when: Date.now() + 2000});
 
-update();
+	browser.runtime.onMessage.addListener(onMessage);
+	browser.runtime.onInstalled.addListener(handleInstalled);
+
+	browser.permissions.onAdded.addListener(addNotificationHandler);
+
+	browser.browserAction.onClicked.addListener(handleBrowserActionClick);
+
+	addNotificationHandler();
+	update();
+}
+
+init();

--- a/source/lib/notifications-service.js
+++ b/source/lib/notifications-service.js
@@ -6,31 +6,84 @@ import localStore from './local-store';
 
 const syncStore = new OptionsSync();
 
-export const closeNotification = async notificationId => {
-	return browser.notifications.clear(notificationId);
-};
+function getLastReadForNotification(notification) {
+	// Extract the specific fragment URL for a notification
+	// This allows you to directly jump to a specif comment as if you were using
+	// the notifications page
+	const lastReadTime = notification.last_read_at;
+	const lastRead = new Date(lastReadTime || notification.updated_at);
 
-export const openNotification = async notificationId => {
-	const url = await localStore.get(notificationId);
-
-	await closeNotification(notificationId);
-
-	if (url) {
-		try {
-			const {json} = await makeApiRequest(new URL(url).pathname);
-			const targetUrl = json.message === 'Not Found' ? await getTabUrl() : json.html_url;
-			return openTab(targetUrl);
-		} catch (_) {
-			return openTab(await getTabUrl());
-		}
+	if (lastReadTime) {
+		lastRead.setSeconds(lastRead.getSeconds() + 1);
 	}
 
-	return false;
+	return lastRead.toISOString();
+}
+
+async function issueOrPRHandler(notification) {
+	const notificationUrl = notification.subject.url;
+
+	try {
+		const {pathname} = new URL(notificationUrl);
+		const lastRead = getLastReadForNotification(notification);
+
+		try {
+			// Try to get the latest comment that the user has not read
+			const {json: comments} = await makeApiRequest(pathname + '/comments', {
+				since: lastRead,
+				per_page: 1 // eslint-disable-line camelcase
+			});
+
+			const comment = comments[0];
+			if (comment) {
+				return comment.html_url;
+			}
+
+			// If there are not comments or events, then just open the url
+			const {json: response} = await makeApiRequest(pathname);
+			const targetUrl = response.message === 'Not Found' ? await getTabUrl() : response.html_url;
+			return targetUrl;
+		} catch (error) {
+			return notificationUrl;
+		}
+	} catch (error) {
+		throw error;
+	}
+}
+
+const notificationHandlers = {
+	/* eslint-disable quote-props */
+	'Issue': issueOrPRHandler,
+	'PullRequest': issueOrPRHandler,
+	'RepositoryInvitation': () => {
+		// @TODO implement in the future
+	}
+	// @TODO: find and implement other notification types
+	/* eslint-enable quote-props */
 };
 
-export const removeNotification = async notificationId => localStore.remove(notificationId);
+export async function closeNotification(notificationId) {
+	return browser.notifications.clear(notificationId);
+}
 
-export const getNotificationObject = notificationInfo => {
+export async function openNotification(notificationId) {
+	const notification = await localStore.get(notificationId);
+	await closeNotification(notificationId);
+	await removeNotification(notificationId);
+
+	try {
+		const urlToOpen = await notificationHandlers[notification.subject.type](notification);
+		return openTab(urlToOpen);
+	} catch (error) {
+		return openTab(await getTabUrl());
+	}
+}
+
+export async function removeNotification(notificationId) {
+	return localStore.remove(notificationId);
+}
+
+export function getNotificationObject(notificationInfo) {
 	return {
 		title: notificationInfo.subject.title,
 		iconUrl: 'icon-notif.png',
@@ -38,43 +91,34 @@ export const getNotificationObject = notificationInfo => {
 		message: notificationInfo.repository.full_name,
 		contextMessage: getNotificationReasonText(notificationInfo.reason)
 	};
-};
+}
 
-export const filterNotificationsByDate = (notifications = [], lastModified) => {
-	const lastModifedTime = new Date(lastModified).getTime();
-	return notifications.filter(n => new Date(n.updated_at).getTime() > lastModifedTime);
-};
-
-export const showNotifications = (notifications = [], lastModified) => {
-	for (const notification of filterNotificationsByDate(notifications, lastModified)) {
+export async function showNotifications(notifications) {
+	for (const notification of notifications) {
 		const notificationId = `github-notifier-${notification.id}`;
 		const notificationObject = getNotificationObject(notification);
+
 		browser.notifications.create(notificationId, notificationObject);
-		localStore.set(notificationId, notification.subject.url);
+
+		localStore.set(notificationId, notification);
 	}
-};
+}
 
-export const playNotification = async (notifications = [], lastModified) => {
-	if (filterNotificationsByDate(notifications, lastModified).length > 0) {
-		const audio = new Audio();
-		audio.src = await browser.extension.getURL('/sounds/bell.ogg');
-		audio.play();
+export async function playNotificationSound() {
+	const audio = new Audio();
+	audio.src = await browser.extension.getURL('/sounds/bell.ogg');
+	audio.play();
+}
 
-		return true;
-	}
-
-	return false;
-};
-
-export const checkNotifications = async lastModified => {
-	const notifications = await getNotifications(100) || [];
+export async function checkNotifications(lastModified) {
+	const notifications = await getNotifications({lastModified});
 	const {showDesktopNotif, playNotifSound} = await syncStore.getAll();
 
-	if (showDesktopNotif) {
-		await showNotifications(notifications, lastModified);
+	if (playNotifSound) {
+		await playNotificationSound();
 	}
 
-	if (playNotifSound) {
-		await playNotification(notifications, lastModified);
+	if (showDesktopNotif) {
+		await showNotifications(notifications);
 	}
-};
+}

--- a/source/lib/notifications-service.js
+++ b/source/lib/notifications-service.js
@@ -55,10 +55,9 @@ const notificationHandlers = {
 	/* eslint-disable quote-props */
 	'Issue': issueOrPRHandler,
 	'PullRequest': issueOrPRHandler,
-	'RepositoryInvitation': () => {
-		// @TODO implement in the future
+	'RepositoryInvitation': notification => {
+		return `${notification.repository.html_url}/invitations`;
 	}
-	// @TODO: find and implement other notification types
 	/* eslint-enable quote-props */
 };
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -98,7 +98,7 @@ test.serial('#getNotificationCount promise resolves response of 0 notifications 
 	global.fetch = fakeFetch();
 
 	const response = await service.getNotificationCount();
-	t.deepEqual(response, {count: 0, interval: 60, lastModified: null});
+	t.deepEqual(response, {count: 0, interval: 60, lastModified: '1970-01-01T00:00:00.000Z'});
 });
 
 test.serial('#getNotificationCount promise resolves response of N notifications according to Link header', async t => {
@@ -112,7 +112,7 @@ test.serial('#getNotificationCount promise resolves response of N notifications 
 		}
 	});
 
-	t.deepEqual(await service.getNotificationCount(), {count: 2, interval: 60, lastModified: null});
+	t.deepEqual(await service.getNotificationCount(), {count: 2, interval: 60, lastModified: '1970-01-01T00:00:00.000Z'});
 
 	global.fetch = fakeFetch({
 		headers: {
@@ -123,7 +123,7 @@ test.serial('#getNotificationCount promise resolves response of N notifications 
 		}
 	});
 
-	t.deepEqual(await service.getNotificationCount(), {count: 3, interval: 60, lastModified: null});
+	t.deepEqual(await service.getNotificationCount(), {count: 3, interval: 60, lastModified: '1970-01-01T00:00:00.000Z'});
 });
 
 test.serial('#makeApiRequest returns rejected promise for 4xx status codes', async t => {


### PR DESCRIPTION
Closes #169

After clicking a notification, based on its type we estimate the last unread comment URL based on
1. `last_unread_at`, may or may not exist, immediate comment of this is what we want
2. `updated_at`, used when `last_unread_at` is missing, gives us _last comment_
3. If both of the above fail, we just open the issue/PR as before

With this PR, we get handlers for each notification type. This allows us to handle notifications for types other than issues and pull-requests, which were ignored until now. (Need to implement other handlers, but issues and PRs should do fine for now)