### PR TITLE
Update notification count after opening a notification

### DIFF
--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -9,7 +9,8 @@ new OptionsSync().define({
 		playNotifSound: false,
 		showDesktopNotif: false,
 		onlyParticipating: false,
-		reuseTabs: false
+		reuseTabs: false,
+		updateCountOnNavigation: false
 	},
 	migrations: [
 		OptionsSync.migrations.removeUnused

--- a/source/options.css
+++ b/source/options.css
@@ -3,6 +3,17 @@ html {
 	overflow-x: hidden;
 }
 
+/* Firefox only */
+.only-firefox {
+	display: none;
+}
+
+@-moz-document url-prefix('') {
+	.only-firefox {
+		display: block;
+	}
+}
+
 :root {
 	--github-green: #28a745;
 	--github-red: #cb2431;

--- a/source/options.html
+++ b/source/options.html
@@ -56,6 +56,10 @@
 			<input type="checkbox" name="reuseTabs" data-request-permission="tabs">
 			Reuse notifications tabs when possible
 		</label>
+		<label>
+			<input type="checkbox" name="updateCountOnNavigation" data-request-permission="tabs">
+			Update notification count after opening a notification
+		</label>
 	</section>
 </form>
 

--- a/source/options.html
+++ b/source/options.html
@@ -3,6 +3,8 @@
 <title>Notifier for GitHub</title>
 <link rel="stylesheet" href="options.css">
 <form id="options-form">
+	<h2 class="only-firefox">Options</h2>
+
 	<section>
 		<h3>Custom URL</h3>
 		<label>

--- a/source/options.js
+++ b/source/options.js
@@ -19,6 +19,11 @@ for (const inputElement of document.querySelectorAll('#options-form [name]')) {
 
 			if (inputElement.checked) {
 				inputElement.checked = await requestPermission(inputElement.dataset.requestPermission);
+
+				// Programatically changing input value does not trigger input events, so save options manually
+				optionsStorage.set({
+					[inputElement.name]: inputElement.checked
+				});
 			}
 		});
 	}

--- a/source/util.js
+++ b/source/util.js
@@ -1,3 +1,19 @@
+import {getHostname} from './lib/api';
+
 export function isChrome() {
 	return navigator.userAgent.includes('Chrome');
+}
+
+export async function isNotificationTargetPage(url) {
+	const urlObject = new URL(url);
+
+	if (urlObject.hostname !== await getHostname()) {
+		return false;
+	}
+
+	const pathname = urlObject.pathname.replace(/^[/]|[/]$/g, ''); // Remove trailing and leading slashes
+	const repoPath = pathname.split('/').slice(2).join('/'); // Everything after `user/repo`
+
+	// Issue, PR, commit paths
+	return /^(((issues|pull)\/\d+(\/(commits|files))?)|(commit\/.*))/.test(repoPath);
 }

--- a/source/util.js
+++ b/source/util.js
@@ -12,8 +12,14 @@ export async function isNotificationTargetPage(url) {
 	}
 
 	const pathname = urlObject.pathname.replace(/^[/]|[/]$/g, ''); // Remove trailing and leading slashes
+
+	// For https://github.com/notifications
+	if (pathname === 'notifications') {
+		return true;
+	}
+
 	const repoPath = pathname.split('/').slice(2).join('/'); // Everything after `user/repo`
 
-	// Issue, PR, commit paths
-	return /^(((issues|pull)\/\d+(\/(commits|files))?)|(commit\/.*))/.test(repoPath);
+	// Issue, PR, commit paths, and per-repo notifications
+	return /^(((issues|pull)\/\d+(\/(commits|files))?)|(commit\/.*)|(notifications$))/.test(repoPath);
 }

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -1,0 +1,54 @@
+import test from 'ava';
+import {isChrome, isNotificationTargetPage} from '../source/util';
+
+test.beforeEach(t => {
+	t.context.defaultOptions = {
+		options: {
+			rootUrl: 'https://api.github.com'
+		}
+	};
+
+	browser.flush();
+
+	global.navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.80 Safari/537.36';
+
+	browser.storage.sync.get.callsFake((key, cb) => {
+		cb(t.context.defaultOptions);
+	});
+});
+
+test.serial('isChrome validates User-Agent string', t => {
+	// Defualt UA string set in fixtures
+	t.is(isChrome(), true);
+
+	// Empty UA string
+	global.navigator.userAgent = '';
+	t.is(isChrome(), false);
+
+	// Firefox
+	global.navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:67.0) Gecko/20100101 Firefox/67.0';
+	t.is(isChrome(), false);
+});
+
+test.serial('isNotificationTargetPage returns true for only valid pages', async t => {
+	// Invalid pages
+	t.throwsAsync(() => isNotificationTargetPage(''));
+	t.is(await isNotificationTargetPage('https://github.com'), false);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus'), false);
+	t.is(await isNotificationTargetPage('https://github.com/notifications'), false);
+	t.is(await isNotificationTargetPage('https://github.com/commit'), false);
+	t.is(await isNotificationTargetPage('https://github.com/commits'), false);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commit'), false);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commits'), false);
+
+	// Valid pages
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/issues/1'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/issues/1#issue-comment-12345'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180/files'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180/files?diff=unified'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180/commits'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180/commits/782fc9132eb515a9b39232893326f3960389918e'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commit/master'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commit/782fc9132eb515a9b39232893326f3960389918e'), true);
+});

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -35,13 +35,17 @@ test.serial('isNotificationTargetPage returns true for only valid pages', async 
 	t.throwsAsync(() => isNotificationTargetPage(''));
 	t.is(await isNotificationTargetPage('https://github.com'), false);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus'), false);
-	t.is(await isNotificationTargetPage('https://github.com/notifications'), false);
+	t.is(await isNotificationTargetPage('https://github.com/notifications/read'), false);
 	t.is(await isNotificationTargetPage('https://github.com/commit'), false);
 	t.is(await isNotificationTargetPage('https://github.com/commits'), false);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commit'), false);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/commits'), false);
 
 	// Valid pages
+	t.is(await isNotificationTargetPage('https://github.com/notifications'), true);
+	t.is(await isNotificationTargetPage('https://github.com/notifications?all=1'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/notifications'), true);
+	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/notifications'), true);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/issues/1'), true);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/issues/1#issue-comment-12345'), true);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/pull/180'), true);


### PR DESCRIPTION
Closes #106.

After opening a notification, like navigating to any of the pages that like the target of a notification, the notification count is updated instead of waiting for the next alarm to trigger.

The option is disabled by default, and requires the `tabs` permission to work. Works similar to "Reuse tabs" feature, to request and handle that permission.

Also adds tests to the new `isNotificationTargetPage()` function and `isChrome()` added previously.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#106: Stop reporting a notification immediately after it's viewed](https://issuehunt.io/repos/18894771/issues/106)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->