### PR TITLE
Fix PR URL returned by handler on API error

### DIFF
--- a/source/lib/notifications-service.js
+++ b/source/lib/notifications-service.js
@@ -46,7 +46,7 @@ async function issueOrPRHandler(notification) {
 		} catch (error) {
 			// If anything related to querying the API fails, extract the URL to issue/PR from the API url
 			url.hostname = await getHostname();
-			url.pathname = url.pathname.replace('/repos', '');
+			url.pathname = url.pathname.replace('/repos', '').replace('/pulls/', '/pull/');
 
 			return url.href;
 		}

--- a/test/notifications-service-test.js
+++ b/test/notifications-service-test.js
@@ -129,6 +129,27 @@ test.serial('#openNotification opens notifications tab on error', async t => {
 	t.true(browser.tabs.create.calledWith({url: 'https://github.com/notifications'}));
 });
 
+test.serial('#openNotification opens API URL when querying the API fails', async t => {
+	const {service, notificationId} = t.context;
+
+	global.fetch = sinon.stub().rejects('error');
+	browser.storage.local.get.withArgs(notificationId)
+		.resolves({
+			[notificationId]: {
+				// eslint-disable-next-line camelcase
+				last_read_at: '2019-04-19T14:44:56Z',
+				subject: {
+					type: 'PullRequest',
+					url: `https://api.github.com/user/repo/pulls/${notificationId}`
+				}
+			}
+		});
+
+	await service.openNotification(notificationId);
+
+	t.true(browser.tabs.create.calledWith({url: `https://github.com/user/repo/pull/${notificationId}`}));
+});
+
 test.serial('#closeNotification returns promise and clears notifications by id', async t => {
 	const {service, notificationId} = t.context;
 


### PR DESCRIPTION
Previously the URL for PRs would end up being similar to `https://github.com/user/repo/pulls/12345` which would direct the user to the PR list with the PR number as the author filter (which pretty much returns no results).
After: The URL will be `https://github.com/user/repo/pull/12345` which is the correct location.

Fixes #185 