### PR TITLE
Fix offline badges even when network is already online

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -53,6 +53,9 @@ function handleError(error) {
 
 function handleOfflineStatus() {
 	renderWarning('offline');
+
+	// Keep schedule for next alarm to keep background active
+	scheduleNextAlarm();
 }
 
 async function update() {


### PR DESCRIPTION
Related to #132 🦄 

The issue is when offline for quite some time, there's no event happened, and chrome turn the extension to inactive. To bypass this behavior, even offline, keep retrying fetching notification, so the online handler still works.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#132: Notifier stays offline despite regaining connection](https://issuehunt.io/repos/18894771/issues/132)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->