### PR TITLE
Reuse the beta notification Tab

### DIFF
--- a/source/util.js
+++ b/source/util.js
@@ -13,8 +13,8 @@ export async function isNotificationTargetPage(url) {
 
 	const pathname = urlObject.pathname.replace(/^[/]|[/]$/g, ''); // Remove trailing and leading slashes
 
-	// For https://github.com/notifications
-	if (pathname === 'notifications') {
+	// For https://github.com/notifications and the beta https://github.com/notifications/beta
+	if (pathname === 'notifications' || pathname === 'notifications/beta') {
 		return true;
 	}
 

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -43,6 +43,8 @@ test.serial('isNotificationTargetPage returns true for only valid pages', async 
 
 	// Valid pages
 	t.is(await isNotificationTargetPage('https://github.com/notifications'), true);
+	t.is(await isNotificationTargetPage('https://github.com/notifications/beta'), true);
+	t.is(await isNotificationTargetPage('https://github.com/notifications/beta?query=is'), true);
 	t.is(await isNotificationTargetPage('https://github.com/notifications?all=1'), true);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/notifications'), true);
 	t.is(await isNotificationTargetPage('https://github.com/sindresorhus/notifier-for-github/notifications'), true);


### PR DESCRIPTION
Hello, I add a new return true for the new beta notification url on the `isNotificationTargetPage`

I have also trouble to build so if some can try on chrome and firefox it will be nice :) 
I use yarn

```
yarn -v
1.21.1
```
```
node -v
v10.18.1
```

```
$ webpack --mode=production
CopyPlugin Invalid Options

options.0 should be string
options.0.ignore should be array
options.0 should match some schema in anyOf

ValidationError: CopyPlugin Invalid Options
    at validateOptions (/home/loic/Development/Perso/notifier-for-github/node_modules/schema-utils/src/validateOptions.js:32:11)
    at new CopyPlugin (/home/loic/Development/Perso/notifier-for-github/node_modules/copy-webpack-plugin/dist/index.js:26:30)
    at Object.<anonymous> (/home/loic/Development/Perso/notifier-for-github/webpack.config.js:20:3)
    at Module._compile (/home/loic/Development/Perso/notifier-for-github/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (/home/loic/Development/Perso/notifier-for-github/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
error Command failed with exit code 1.

```