### PR TITLE
Remove hardcoded protocol for notification page URL

### DIFF
--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -8,9 +8,9 @@ export async function getGitHubOrigin() {
 	// TODO: Drop `api.github.com` check when dropping migrations
 	if (origin === 'https://api.github.com' || origin === 'https://github.com') {
 		return 'https://github.com';
-	} else {
-		return origin;
 	}
+
+	return origin;
 }
 
 export async function getTabUrl() {
@@ -27,9 +27,9 @@ export async function getApiUrl() {
 	// TODO: Drop `api.github.com` check when dropping migrations
 	if (origin === 'https://api.github.com' || origin === 'https://github.com') {
 		return origin;
-	} else {
-		return `${origin}/api/v3`;
 	}
+
+	return `${origin}/api/v3`;
 }
 
 export async function getParsedUrl(endpoint, params) {

--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -1,41 +1,35 @@
 import optionsStorage from '../options-storage';
 import {parseLinkHeader} from '../util';
 
-export async function getHostname() {
+export async function getGitHubOrigin() {
 	const {rootUrl} = await optionsStorage.getAll();
+	const {origin} = new URL(rootUrl);
 
-	if (/(^(https:\/\/)?(api\.)?github\.com)/.test(rootUrl)) {
-		return 'github.com';
+	// TODO: Drop `api.github.com` check when dropping migrations
+	if (origin === 'https://api.github.com' || origin === 'https://github.com') {
+		return 'https://github.com';
+	} else {
+		return origin;
 	}
-
-	return (new URL(rootUrl)).hostname;
 }
 
 export async function getTabUrl() {
 	const {onlyParticipating} = await optionsStorage.getAll();
 	const useParticipating = onlyParticipating ? '/participating' : '';
 
-	return `${await getRootUrl()}/notifications${useParticipating}`;
+	return `${await getGitHubOrigin()}/notifications${useParticipating}`;
 }
 
 export async function getApiUrl() {
 	const {rootUrl} = await optionsStorage.getAll();
+	const {origin} = new URL(rootUrl);
 
-	if (/(^(https:\/\/)?(api\.)?github\.com)/.test(rootUrl)) {
-		return 'https://api.github.com';
+	// TODO: Drop `api.github.com` check when dropping migrations
+	if (origin === 'https://api.github.com' || origin === 'https://github.com') {
+		return origin;
+	} else {
+		return `${origin}/api/v3`;
 	}
-
-	return `${rootUrl}api/v3`;
-}
-
-export async function getRootUrl() {
-	const {rootUrl} = await optionsStorage.getAll();
-
-	if (/(^(https:\/\/)?(api\.)?github\.com)/.test(rootUrl)) {
-		return 'https://github.com';
-	}
-
-	return rootUrl.replace(/[/]$/, '');
 }
 
 export async function getParsedUrl(endpoint, params) {

--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -15,7 +15,7 @@ export async function getTabUrl() {
 	const {onlyParticipating} = await optionsStorage.getAll();
 	const useParticipating = onlyParticipating ? '/participating' : '';
 
-	return `https://${await getHostname()}/notifications${useParticipating}`;
+	return `${await getRootUrl()}/notifications${useParticipating}`;
 }
 
 export async function getApiUrl() {
@@ -26,6 +26,16 @@ export async function getApiUrl() {
 	}
 
 	return `${rootUrl}api/v3`;
+}
+
+export async function getRootUrl() {
+	const {rootUrl} = await optionsStorage.getAll();
+
+	if (/(^(https:\/\/)?(api\.)?github\.com)/.test(rootUrl)) {
+		return 'https://github.com';
+	}
+
+	return rootUrl.replace(/[/]$/, '');
 }
 
 export async function getParsedUrl(endpoint, params) {

--- a/source/util.js
+++ b/source/util.js
@@ -1,4 +1,4 @@
-import {getHostname} from './lib/api';
+import {getGitHubOrigin} from './lib/api';
 
 export function isChrome() {
 	return navigator.userAgent.includes('Chrome');
@@ -12,7 +12,7 @@ export function parseFullName(fullName) {
 export async function isNotificationTargetPage(url) {
 	const urlObject = new URL(url);
 
-	if (urlObject.hostname !== (await getHostname())) {
+	if (urlObject.origin !== (await getGitHubOrigin())) {
 		return false;
 	}
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -47,6 +47,48 @@ test.serial('#getApiUrl uses custom endpoint if rootUrl is something other than 
 	t.is(await service.getApiUrl(), 'https://something.com/api/v3');
 });
 
+test.serial('#getRootUrl uses default endpoint if rootUrl matches GitHub API url', async t => {
+	const {service} = t.context;
+
+	browser.storage.sync.get.callsFake((key, cb) => {
+		cb({
+			options: {
+				rootUrl: 'https://api.github.com/'
+			}
+		});
+	});
+
+	t.is(await service.getRootUrl(), 'https://github.com');
+});
+
+test.serial('#getRootUrl uses custom endpoint if rootUrl is something other than GitHub', async t => {
+	const {service} = t.context;
+
+	browser.storage.sync.get.callsFake((storageName, callback) => {
+		callback({
+			options: {
+				rootUrl: 'https://something.com'
+			}
+		});
+	});
+
+	t.is(await service.getRootUrl(), 'https://something.com');
+});
+
+test.serial('#getRootUrl uses custom endpoint if rootUrl has end slash it is removed', async t => {
+	const {service} = t.context;
+
+	browser.storage.sync.get.callsFake((storageName, callback) => {
+		callback({
+			options: {
+				rootUrl: 'https://something.com/'
+			}
+		});
+	});
+
+	t.is(await service.getRootUrl(), 'https://something.com');
+});
+
 test.serial('#getTabUrl uses default page if rootUrl matches GitHub', async t => {
 	const {service} = t.context;
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -47,7 +47,7 @@ test.serial('#getApiUrl uses custom endpoint if rootUrl is something other than 
 	t.is(await service.getApiUrl(), 'https://something.com/api/v3');
 });
 
-test.serial('#getRootUrl uses default endpoint if rootUrl matches GitHub API url', async t => {
+test.serial('#getGitHubOrigin uses default endpoint if rootUrl matches GitHub API url', async t => {
 	const {service} = t.context;
 
 	browser.storage.sync.get.callsFake((key, cb) => {
@@ -58,10 +58,10 @@ test.serial('#getRootUrl uses default endpoint if rootUrl matches GitHub API url
 		});
 	});
 
-	t.is(await service.getRootUrl(), 'https://github.com');
+	t.is(await service.getGitHubOrigin(), 'https://github.com');
 });
 
-test.serial('#getRootUrl uses custom endpoint if rootUrl is something other than GitHub', async t => {
+test.serial('#getGitHubOrigin uses custom endpoint if rootUrl is something other than GitHub', async t => {
 	const {service} = t.context;
 
 	browser.storage.sync.get.callsFake((storageName, callback) => {
@@ -72,10 +72,10 @@ test.serial('#getRootUrl uses custom endpoint if rootUrl is something other than
 		});
 	});
 
-	t.is(await service.getRootUrl(), 'https://something.com');
+	t.is(await service.getGitHubOrigin(), 'https://something.com');
 });
 
-test.serial('#getRootUrl uses custom endpoint if rootUrl has end slash it is removed', async t => {
+test.serial('#getGitHubOrigin uses custom endpoint if rootUrl has end slash it is removed', async t => {
 	const {service} = t.context;
 
 	browser.storage.sync.get.callsFake((storageName, callback) => {
@@ -86,7 +86,7 @@ test.serial('#getRootUrl uses custom endpoint if rootUrl has end slash it is rem
 		});
 	});
 
-	t.is(await service.getRootUrl(), 'https://something.com');
+	t.is(await service.getGitHubOrigin(), 'https://something.com');
 });
 
 test.serial('#getTabUrl uses default page if rootUrl matches GitHub', async t => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -39,12 +39,12 @@ test.serial('#getApiUrl uses custom endpoint if rootUrl is something other than 
 	browser.storage.sync.get.callsFake((storageName, callback) => {
 		callback({
 			options: {
-				rootUrl: 'https://something.com/'
+				rootUrl: 'https://git.something.com/'
 			}
 		});
 	});
 
-	t.is(await service.getApiUrl(), 'https://something.com/api/v3');
+	t.is(await service.getApiUrl(), 'https://git.something.com/api/v3');
 });
 
 test.serial('#getGitHubOrigin uses default endpoint if rootUrl matches GitHub API url', async t => {
@@ -67,26 +67,40 @@ test.serial('#getGitHubOrigin uses custom endpoint if rootUrl is something other
 	browser.storage.sync.get.callsFake((storageName, callback) => {
 		callback({
 			options: {
-				rootUrl: 'https://something.com'
+				rootUrl: 'http://git.something.com/'
 			}
 		});
 	});
 
-	t.is(await service.getGitHubOrigin(), 'https://something.com');
+	t.is(await service.getGitHubOrigin(), 'http://git.something.com');
 });
 
-test.serial('#getGitHubOrigin uses custom endpoint if rootUrl has end slash it is removed', async t => {
+test.serial('#getGitHubOrigin uses custom endpoint if rootUrl has trailing slash removed', async t => {
 	const {service} = t.context;
 
 	browser.storage.sync.get.callsFake((storageName, callback) => {
 		callback({
 			options: {
-				rootUrl: 'https://something.com/'
+				rootUrl: 'https://git.something.com'
 			}
 		});
 	});
 
-	t.is(await service.getGitHubOrigin(), 'https://something.com');
+	t.is(await service.getGitHubOrigin(), 'https://git.something.com');
+});
+
+test.serial('#getGitHubOrigin respects "http:" protocol on non-GitHub servers', async t => {
+	const {service} = t.context;
+
+	browser.storage.sync.get.callsFake((storageName, callback) => {
+		callback({
+			options: {
+				rootUrl: 'http://git.something.com/'
+			}
+		});
+	});
+
+	t.is(await service.getGitHubOrigin(), 'http://git.something.com');
 });
 
 test.serial('#getTabUrl uses default page if rootUrl matches GitHub', async t => {
@@ -110,13 +124,13 @@ test.serial('#getTabUrl uses uses custom page if rootUrl is something other than
 	browser.storage.sync.get.callsFake((storageName, callback) => {
 		callback({
 			options: {
-				rootUrl: 'https://something.com/',
+				rootUrl: 'https://git.something.com/',
 				onlyParticipating: false
 			}
 		});
 	});
 
-	t.is(await service.getTabUrl(), 'https://something.com/notifications');
+	t.is(await service.getTabUrl(), 'https://git.something.com/notifications');
 });
 
 test.serial('#getTabUrl respects useParticipatingCount setting', async t => {

--- a/test/notifications-service-test.js
+++ b/test/notifications-service-test.js
@@ -74,7 +74,7 @@ test.serial('#openNotification clears notification from queue by notificationId'
 
 	await service.openNotification(notificationId);
 
-	t.true(browser.notifications.clear.calledWithMatch(notificationId));
+	t.true(browser.notifications.clear.calledWith(notificationId));
 });
 
 test.serial('#openNotification skips network requests if no url returned by local-store', async t => {


### PR DESCRIPTION
Fixes #198 

I created another function who gets the `rootUrl` and processing like removing the last `/` if exist and if `api.github.com` it's will return github website.

Maybe the better way is to create another option?