### PR TITLE
Use persistent background pages

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -19,7 +19,8 @@ async function scheduleNextAlarm(interval) {
 	// Delay less than 1 minute will cause a warning
 	const delayInMinutes = Math.max(Math.ceil(intervalValue / 60), 1);
 
-	browser.alarms.create({delayInMinutes});
+	browser.alarms.clearAll();
+	browser.alarms.create('update', {delayInMinutes});
 }
 
 async function handleLastModified(newLastModified) {
@@ -47,15 +48,12 @@ async function updateNotificationCount() {
 
 function handleError(error) {
 	scheduleNextAlarm();
-
 	renderError(error);
 }
 
 function handleOfflineStatus() {
-	renderWarning('offline');
-
-	// Keep schedule for next alarm to keep background active
 	scheduleNextAlarm();
+	renderWarning('offline');
 }
 
 async function update() {
@@ -77,14 +75,6 @@ async function handleBrowserActionClick() {
 function handleInstalled(details) {
 	if (details.reason === 'install') {
 		browser.runtime.openOptionsPage();
-	}
-}
-
-function handleConnectionStatus() {
-	if (navigator.onLine) {
-		update();
-	} else {
-		handleOfflineStatus();
 	}
 }
 
@@ -125,11 +115,11 @@ async function addHandlers() {
 }
 
 function init() {
-	window.addEventListener('online', handleConnectionStatus);
-	window.addEventListener('offline', handleConnectionStatus);
+	window.addEventListener('online', update);
+	window.addEventListener('offline', update);
 
 	browser.alarms.onAlarm.addListener(update);
-	browser.alarms.create({when: Date.now() + 2000});
+	scheduleNextAlarm();
 
 	browser.runtime.onMessage.addListener(onMessage);
 	browser.runtime.onInstalled.addListener(handleInstalled);

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -23,7 +23,7 @@
 		"notifications"
 	],
 	"background": {
-		"persistent": false,
+		"persistent": true,
 		"scripts": [
 			"browser-polyfill.min.js",
 			"background.js"


### PR DESCRIPTION
On Chrome we had this long standing issue where the extension goes offline until you click on the extension icon (#132) or trigger background pages some other way. In some cases it goes completely unresponsive despite clicking on the extension icon (#220).

We haven't had similar issues on Firefox, which does not (yet) support non-persistent background pages, i.e., the background page stays loaded all the time.

https://developer.chrome.com/extensions/background_pages

Chrome suggests not to have resource intensive tasks in background pages, but all we have in background pages is an alarm, and a couple of network requests, so this should not be a problem.

I'm hoping changing to the same persistent model as Firefox on Chrome should fix issues mentioned above.

/cc @fregante and @sindresorhus for opinions.