### PR TITLE
Fix `<summary>` styles for extension options on Firefox

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -76,16 +76,14 @@ input[type='text'][name='token'] {
 	margin: 0.25em 0 0.5em;
 }
 
+.repo-wrapper ul,
 .repo-wrapper ul > li {
 	list-style-type: none;
 }
 
-.repo-wrapper summary {
-	display: flex;
-	align-items: center;
-}
-
 .repo-wrapper label {
+	display: inline-block;
+	width: auto;
 	margin: 0;
 	margin-bottom: 0.25rem;
 }


### PR DESCRIPTION
In the options view, using `display: flex` on `<summary>` causes them to loose UA styles for showing markers. This resulted in a bug where the marker isn't shown and user had no idea that they can expand the list.

| Before | After |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/37769974/89118928-c11ae100-d45e-11ea-942f-37cfeeba6967.png) | ![image](https://user-images.githubusercontent.com/37769974/89118936-db54bf00-d45e-11ea-9bc1-69a4ba100829.png) |


This PR resets its style and users other selectors to align content inside `<label>` elements.