### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
-env: {}
+env:
+  DIRECTORY: distribution
 
-# DO NOT EDIT BELOW, USE: npx ghat fregante/ghatemplates/webext --set 'on.schedule=[{"cron": "21 12 * * 3"}]'
+# FILE GENERATED WITH: npx ghat fregante/ghatemplates/webext
+# SOURCE: https://github.com/fregante/ghatemplates
+# OPTIONS: {"set":["on.schedule=[{\"cron\": \"21 12 * * 3\"}]"]}
 
 name: Release
 on:
@@ -10,8 +13,8 @@ on:
 jobs:
   Version:
     outputs:
-      created: '${{ steps.daily-version.outputs.created }}'
-      version: '${{ steps.daily-version.outputs.version }}'
+      created: ${{ steps.daily-version.outputs.created }}
+      version: ${{ steps.daily-version.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,10 +26,10 @@ jobs:
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version
-      - uses: notlmn/release-with-changelog@v3
+      - uses: fregante/release-with-changelog@v3
         if: steps.daily-version.outputs.created
         with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: ${{ secrets.GITHUB_TOKEN }}
           exclude: true
   Submit:
     needs: Version
@@ -42,16 +45,25 @@ jobs:
       - uses: actions/checkout@v2
       - name: install
         run: npm ci || npm install
-      - run: npm run build
+      - run: npm run build --if-present
       - name: Update extension’s meta
         run: >-
-          npx dot-json distribution/manifest.json version ${{
+          npx dot-json@1 $DIRECTORY/manifest.json version ${{
           needs.Version.outputs.version }}
-      - run: 'npm run release:${{ matrix.command }}'
+      - name: Submit
+        run: |
+          case ${{ matrix.command }} in
+            chrome)
+              cd $DIRECTORY && npx chrome-webstore-upload-cli@1 upload --auto-publish
+              ;;
+            firefox)
+              cd $DIRECTORY && npx web-ext-submit@5
+              ;;
+          esac
         env:
-          EXTENSION_ID: '${{ secrets.EXTENSION_ID }}'
-          CLIENT_ID: '${{ secrets.CLIENT_ID }}'
-          CLIENT_SECRET: '${{ secrets.CLIENT_SECRET }}'
-          REFRESH_TOKEN: '${{ secrets.REFRESH_TOKEN }}'
-          WEB_EXT_API_KEY: '${{ secrets.WEB_EXT_API_KEY }}'
-          WEB_EXT_API_SECRET: '${{ secrets.WEB_EXT_API_SECRET }}'
+          EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
 		"test": "run-s lint:* test:* build",
 		"test:js": "ava",
 		"build": "webpack --mode=production",
-		"watch": "webpack --mode=development --watch",
-		"release:firefox": "cd distribution && webstore upload --auto-publish",
-		"release:chrome": "cd distribution && web-ext-submit"
+		"watch": "webpack --mode=development --watch"
 	},
 	"dependencies": {
 		"delay": "^4.3.0",
@@ -21,10 +19,7 @@
 	"devDependencies": {
 		"@types/chrome": "0.0.86",
 		"ava": "^2.2.0",
-		"chrome-webstore-upload-cli": "^1.2.0",
 		"copy-webpack-plugin": "^5.0.4",
-		"daily-version": "^1.0.0",
-		"dot-json": "^1.1.0",
 		"esm": "^3.2.25",
 		"lodash.merge": "^4.6.2",
 		"moment": "^2.24.0",
@@ -35,8 +30,6 @@
 		"stylelint": "^10.1.0",
 		"stylelint-config-xo": "^0.15.0",
 		"terser-webpack-plugin": "^1.4.1",
-		"web-ext": "^3.2.1",
-		"web-ext-submit": "^3.2.1",
 		"webpack": "^4.38.0",
 		"webpack-cli": "^3.3.6",
 		"xo": "^0.24.0"


### PR DESCRIPTION
File updated by running:

```
$ npx ghat
```

Release dependencies and scripts are no longer part of package.json; I think this covers everything.

Cronjob and trigger remain unchanged. 