### PR TITLE
Only register the notification click handler once

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -97,13 +97,15 @@ async function onTabUpdated(tabId, changeInfo, tab) {
 	}
 }
 
+function openNotificationSync(id) {
+    openNotification(id);
+}
+
 async function addHandlers() {
 	const {updateCountOnNavigation} = await optionsStorage.getAll();
 
 	if (await queryPermission('notifications')) {
-		browser.notifications.onClicked.addListener(id => {
-			openNotification(id);
-		});
+		browser.notifications.onClicked.addListener(openNotificationSync);
 	}
 
 	if (await queryPermission('tabs')) {

--- a/source/background.js
+++ b/source/background.js
@@ -98,7 +98,7 @@ async function onTabUpdated(tabId, changeInfo, tab) {
 }
 
 function openNotificationSync(id) {
-    openNotification(id);
+	openNotification(id);
 }
 
 async function addHandlers() {

--- a/source/background.js
+++ b/source/background.js
@@ -97,7 +97,7 @@ async function onTabUpdated(tabId, changeInfo, tab) {
 	}
 }
 
-function openNotificationSync(id) {
+function onNotificationClick(id) {
 	openNotification(id);
 }
 
@@ -105,7 +105,7 @@ async function addHandlers() {
 	const {updateCountOnNavigation} = await optionsStorage.getAll();
 
 	if (await queryPermission('notifications')) {
-		browser.notifications.onClicked.addListener(openNotificationSync);
+		browser.notifications.onClicked.addListener(onNotificationClick);
 	}
 
 	if (await queryPermission('tabs')) {


### PR DESCRIPTION
This PR replaces the handler for `browser.notification.onClicked.addListener` with a named function, which avoids re-registering the handler on every call to `addHandlers`.

Note that `addEventListener` called repeatedly with the same arguments will not register the same event listener multiple times (see the [`EventTarget.addEventListener` spec](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget-addEventListener) for more info). This means that using the same named function for each call to `addHandlers` will only call that function once, where the previous code added a new anonymous function for each call.

This fixes #234, where clicking a notification would result in multiple tabs being opened, depending on the number of times that `addHandlers` was called.