### PR TITLE
Notification titles can be seen when badge is hovered

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -5,7 +5,7 @@ import localStore from './lib/local-store.js';
 import {openTab} from './lib/tabs-service.js';
 import {queryPermission} from './lib/permissions-service.js';
 import {getNotificationCount, getTabUrl} from './lib/api.js';
-import {renderCount, renderError, renderWarning} from './lib/badge.js';
+import {renderCount, renderText, renderError, renderWarning} from './lib/badge.js';
 import {checkNotifications, openNotification} from './lib/notifications-service.js';
 import {isChrome, isNotificationTargetPage} from './util.js';
 
@@ -40,9 +40,10 @@ async function handleLastModified(newLastModified) {
 
 async function updateNotificationCount() {
 	const response = await getNotificationCount();
-	const {count, interval, lastModified} = response;
+	const {count, interval, notifications, lastModified} = response;
 
-	renderCount(count);
+	const badgeText = notifications.reduce((text, notification)=> text + notification.reason + '=>' + notification.subject.title + "\n" , "");
+	renderText(count, badgeText);
 	scheduleNextAlarm(interval);
 	handleLastModified(lastModified);
 }

--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -133,6 +133,7 @@ export async function getNotificationCount() {
 		return {
 			count: notifications.length,
 			interval,
+			notifications,
 			lastModified
 		};
 	}
@@ -147,6 +148,7 @@ export async function getNotificationCount() {
 	return {
 		count,
 		interval,
+		notifications,
 		lastModified
 	};
 }

--- a/source/lib/badge.js
+++ b/source/lib/badge.js
@@ -25,6 +25,12 @@ function getErrorData(error) {
 	return {symbol, title};
 }
 
+export function renderText(count, notificationsString) {
+	const color = defaults.getBadgeDefaultColor();
+	const title = defaults.defaultTitle + "\n" + notificationsString;
+	render(getCountString(count), color, title);
+}
+
 export function renderCount(count) {
 	const color = defaults.getBadgeDefaultColor();
 	const title = defaults.defaultTitle;


### PR DESCRIPTION
Hello everybody,

I don't like `https://github.com/notifications`: It's pretty messy, I can't get notifications from my job on the desktop, and the user interface is so confusing: notifications are mixed between different categories, sometimes I click a review requested and I have no review requested, the numbers usually don't match, I get confused between read, unread and done notifications, etc.

Fortunately I found this browser extension, and I really enjoy it. I can narrow down the number of repositories which I need to be alerted ASAP, and I can get alerts in real time so I can focus in emergencies if that's the case. But I am missing something. I'd like to see a quick summary of all the notifications I have unread. And what I have done in this branch aims in that direction.

What I've achieved until now is very hacky but works, but it would be great to have something fancier like a widget or a special page. I don't know well what are the limitations of working with a browser extension.

I just wanted to propose this idea, and hear what you guys may think about it. Is the feature I am proposing on the scope of this project? How can it be done better?

I'll need to fix the tests because I broke two of them on this branch.  

PS: How do you do guys to test the extension in a real life situation? I took a glance at the tests (mainly at `test/notifications-service-test.js`) and there you are creating some fake data to simulate notifications. I've used [web-ext](https://github.com/mozilla/web-ext) to auto reload the extension on the browser (like you do on [refined-github](https://github.com/refined-github/refined-github/blob/main/contributing.md#loading-into-the-browser)) but I wonder if there is any way to actually create some fake notifications on github in order to test the extension in a real world scenario. I'm bringing this up because when I load the extension on this branch in my browser. I got `count == 4`, and when I hover the badge I've got only one notification listed. So weird. Any tips on debugging this extension would be appreciated.

Best,