### PR TITLE
Fix calling toGMTString on lastModified

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -25,9 +25,9 @@ async function scheduleNextAlarm(interval) {
 }
 
 async function handleLastModified(newLastModified) {
-	const lastModified = await localStore.get('lastModified') || new Date(0);
+	const lastModified = await localStore.get('lastModified') || new Date(0).toUTCString();
 
-	// Something has changed since we last accessed, display any new notificaitons
+	// Something has changed since we last accessed, display any new notifications
 	if (newLastModified !== lastModified) {
 		const {showDesktopNotif, playNotifSound} = await optionsStorage.getAll();
 		if (showDesktopNotif === true || playNotifSound === true) {

--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -126,7 +126,7 @@ export async function getNotificationCount() {
 	const {headers, json: notifications} = await getNotificationResponse({maxItems: 1});
 
 	const interval = Number(headers.get('X-Poll-Interval'));
-	const lastModified = (new Date(headers.get('Last-Modified'))).toGMTString();
+	const lastModified = (new Date(headers.get('Last-Modified'))).toUTCString();
 	const linkHeader = headers.get('Link');
 
 	if (linkHeader === null) {

--- a/source/lib/notifications-service.js
+++ b/source/lib/notifications-service.js
@@ -125,7 +125,7 @@ export function playNotificationSound() {
 }
 
 export async function checkNotifications(lastModified) {
-	let notifications = await getNotifications({lastModified: lastModified.toGMTString()});
+	let notifications = await getNotifications({lastModified});
 	const {showDesktopNotif, playNotifSound, filterNotifications} = await optionsStorage.getAll();
 
 	if (filterNotifications) {


### PR DESCRIPTION
This fixes #276.

Function `checkNotifications` is always passed a *string* value for `lastModified` (unless, `localStore` is empty, in which case a `Date` *object* is created), so calling `toGMTString()` resulted in an error.

This change does the following:

1. Fix the bug by removing unneeded `toGMTString()` call
2. make sure `lastModified` is always a *string*, even when `localStore` is empty
3. Use `toUTCString()` as it is more consistent with how JS interprets time.


