### PR TITLE
Add sanity checks for permissions

### DIFF
--- a/source/lib/notifications-service.js
+++ b/source/lib/notifications-service.js
@@ -7,6 +7,7 @@ import {makeApiRequest, getNotifications, getTabUrl, getGitHubOrigin} from './ap
 import {getNotificationReasonText} from './defaults.js';
 import {openTab} from './tabs-service.js';
 import localStore from './local-store.js';
+import {queryPermission} from './permissions-service.js';
 
 function getLastReadForNotification(notification) {
 	// Extract the specific fragment URL for a notification
@@ -107,6 +108,11 @@ export function getNotificationObject(notificationInfo) {
 }
 
 export async function showNotifications(notifications) {
+	const permissionGranted = await queryPermission('notifications');
+	if (!permissionGranted) {
+		return;
+	}
+
 	for (const notification of notifications) {
 		const notificationId = `github-notifier-${notification.id}`;
 		const notificationObject = getNotificationObject(notification);

--- a/source/lib/tabs-service.js
+++ b/source/lib/tabs-service.js
@@ -1,6 +1,7 @@
 import browser from 'webextension-polyfill';
 import optionsStorage from '../options-storage.js';
 import {isChrome} from '../util.js';
+import {queryPermission} from './permissions-service.js';
 
 export const emptyTabUrls = isChrome() ? [
 	'chrome://newtab/',
@@ -22,8 +23,8 @@ export async function queryTabs(urlList) {
 
 export async function openTab(url) {
 	const {reuseTabs} = await optionsStorage.getAll();
-
-	if (reuseTabs) {
+	const permissionGranted = await queryPermission('tabs');
+	if (reuseTabs && permissionGranted) {
 		const matchingUrls = [url];
 		if (url.endsWith('/notifications')) {
 			matchingUrls.push(url + '?query=is%3Aunread');


### PR DESCRIPTION
Fixes #278.


`browser.notifications.create` is `undefined` when notification permission is _not granted_.

This makes calls to function `showNotifications` fail stopping the program flow and preventing saving `lastModified` field.

Also perhaps we need to unset permission-related options whenever a permission is removed.
`onRemove`[1] listener is a good approach.

[1]
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved