### PR TITLE
Updating auth header to use Bearer

### DIFF
--- a/source/lib/api.js
+++ b/source/lib/api.js
@@ -47,7 +47,7 @@ export async function getHeaders() {
 
 	return {
 		/* eslint-disable quote-props */
-		'Authorization': `token ${token}`,
+		'Authorization': `Bearer ${token}`,
 		'If-Modified-Since': ''
 		/* eslint-enable quote-props */
 	};


### PR DESCRIPTION
Not able to get this to work on latest GHES instance and noticed it's using 'token' as the auth header.  Tested in postman and works only using 'Bearer'.


https://docs.github.com/en/enterprise-server@3.8/rest/overview/authenticating-to-the-rest-api#about-authentication