### PR TITLE
Add note about public GitHub instance URL on options page

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -11,7 +11,7 @@
 			<h4>Root URL</h4>
 			<input type="url" name="rootUrl" placeholder="e.g. https://github.yourco.com/">
 		</label>
-		<p class="small">Specify the root URL to your GitHub Enterprise.</p>
+		<p class="small">Specify the root URL to your GitHub Enterprise. For public GitHub instance this should be `https://github.com`</p>
 
 		<label>
 			<h4>Token</h4>


### PR DESCRIPTION
Fixes #288