### PR TITLE
Remove "api." suffix from default rootUrl

### DIFF
--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -3,7 +3,7 @@ import OptionsSync from 'webext-options-sync';
 const optionsStorage = new OptionsSync({
 	defaults: {
 		token: '',
-		rootUrl: 'https://api.github.com/',
+		rootUrl: 'https://github.com/',
 		playNotifSound: false,
 		showDesktopNotif: false,
 		onlyParticipating: false,


### PR DESCRIPTION
Match the description for (e.g.) new installations, see https://github.com/sindresorhus/notifier-for-github/blob/7aade100e6b4d3745406deee7bfe5d36c30353ea/source/options.html#L15